### PR TITLE
#6 [Feature] 번역 API 호출 실패 시 재처리 로직 구현

### DIFF
--- a/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
@@ -25,7 +25,12 @@ public enum ErrorCode {
 
     //Daily
     DUPLICATE_DAILY(HttpStatus.CONFLICT, "DLY-001", "이미 존재하는 일일 컨텐츠입니다"),
-    DAILY_NOT_FOUND(HttpStatus.CONFLICT, "DLY-002", "존재하지 않는 일일 컨텐츠입니다");
+    DAILY_NOT_FOUND(HttpStatus.CONFLICT, "DLY-002", "존재하지 않는 일일 컨텐츠입니다"),
+
+    //Sentence
+    TRANSLATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SNT-001", "번역 처리 중 오류가 발생했습니다"),
+    TRANSLATION_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "SNT-002", "번역 작업이 중단되었습니다"),
+    SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "SNT-003", "존재하지 않는 문장입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/newslit/backend/sentence/Sentence.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/Sentence.java
@@ -67,7 +67,15 @@ public class Sentence {
     @Builder.Default
     private Status translationStatus = Status.PENDING;
 
+    @Column(name = "retry_count", nullable = false)
+    @Builder.Default
+    private int retryCount = 0;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
 }

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceController.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceController.java
@@ -19,8 +19,7 @@ public class SentenceController {
     private final SentenceService sentenceService;
 
     @GetMapping
-    ResponseEntity<List<SentenceResponseDto>> translateOneParagraph(@RequestParam(name = "articleId") Long articleId)
-            throws DeepLException, InterruptedException {
+    ResponseEntity<List<SentenceResponseDto>> translateOneParagraph(@RequestParam(name = "articleId") Long articleId) {
         List<SentenceResponseDto> responses = sentenceService.translateOneParagraph(articleId);
 
         return ResponseEntity.ok(responses);

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceRepository.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SentenceRepository extends JpaRepository<Sentence, Long> {
-    List<Sentence> findAllByTranslationStatus(Status status);
+    List<Sentence> findAllByTranslationStatusAndRetryCountLessThan(Status status, int count);
 
     List<Sentence> findAllByArticleId(Long id);
 

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceScheduler.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceScheduler.java
@@ -28,7 +28,6 @@ public class SentenceScheduler {
         int failCount = 0;
 
         for (Sentence sentence : failedSentences) {
-            sentence.incrementRetryCount();
             try {
                 sentenceService.retryTranslation(sentence);
                 successCount++;

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceScheduler.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceScheduler.java
@@ -1,0 +1,43 @@
+package com.newslit.backend.sentence;
+
+import com.newslit.backend.global.common.enums.Status;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SentenceScheduler {
+    private static final int MAX_RETRY_COUNT = 10;
+    private static final long RETRY_INTERVAL_MS = 300_000;
+
+    private final SentenceService sentenceService;
+    private final SentenceRepository sentenceRepository;
+
+    @Scheduled(fixedDelay = RETRY_INTERVAL_MS)
+    public void retryFailedTranslations() {
+        List<Sentence> failedSentences = sentenceRepository
+                .findAllByTranslationStatusAndRetryCountLessThan(Status.FAILED, MAX_RETRY_COUNT);
+
+        log.info("재처리 대상: {}건", failedSentences.size());
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (Sentence sentence : failedSentences) {
+            sentence.incrementRetryCount();
+            try {
+                sentenceService.retryTranslation(sentence);
+                successCount++;
+            } catch (Exception e) {
+                failCount++;
+                log.error("재처리 중 예외 발생 - Sentence ID: {}", sentence.getId(), e);
+            }
+        }
+
+        log.info("재처리 완료 - 성공: {}건, 실패: {}건", successCount, failCount);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -6,14 +6,13 @@ import com.newslit.backend.article.Article;
 import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.article.exception.ArticleNotFoundException;
 import com.newslit.backend.global.common.enums.Status;
-import com.newslit.backend.global.setup.DataSetupRunner;
 import com.newslit.backend.sentence.dto.SentenceResponseDto;
+import com.newslit.backend.sentence.exception.TranslationFailedException;
+import com.newslit.backend.sentence.exception.TranslationInterruptedException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,11 +22,10 @@ public class SentenceService {
     private final DeepLClient deepLClient;
     private final SentenceRepository sentenceRepository;
     private final ArticleRepository articleRepository;
-    private static final Logger log = LoggerFactory.getLogger(DataSetupRunner.class);
 
-    public List<SentenceResponseDto> translateOneParagraph(Long articleId) throws DeepLException, InterruptedException {
+    public List<SentenceResponseDto> translateOneParagraph(Long articleId) {
         Article article = articleRepository.findById(articleId)
-                .orElseThrow(() -> new ArticleNotFoundException());
+                .orElseThrow(ArticleNotFoundException::new);
 
         String paragraph = article.getOriginalText();
         List<String> sentences = splitIntoSentencesAdvanced(paragraph);
@@ -43,46 +41,68 @@ public class SentenceService {
 
     @Transactional
     public SentenceResponseDto translateSingleSentence(Long articleId, Article article, String englishText,
-                                                       int orderIndex)
-            throws DeepLException, InterruptedException {
+                                                       int orderIndex) {
 
         Optional<Sentence> existing = sentenceRepository
                 .findByArticleIdAndEnglishText(articleId, englishText);
 
-        Sentence sentence;
-
-        if (existing.isPresent()) {
-            sentence = existing.get();
-            if (sentence.getTranslationStatus() == Status.SUCCESS) {
-                return toSentenceDto(sentence);
-            }
-            sentence.setTranslationStatus(Status.PROCESSING);
-            sentenceRepository.save(sentence);
-
-        } else {
-            sentence = Sentence.builder()
-                    .article(article)
-                    .translationStatus(Status.PROCESSING)
-                    .orderIndex(orderIndex)
-                    .englishText(englishText)
-                    .koreanText("")
-                    .build();
-            sentence = sentenceRepository.save(sentence);
+        //이미 번역 성공하여 저장되어있으면 pass
+        if (existing.isPresent() && existing.get().getTranslationStatus() == Status.SUCCESS) {
+            return toSentenceDto(existing.get());
         }
 
-        String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
+        //실패 상태거나, 없는 문장이면 해석 API 호출
+        Sentence sentence = existing.orElseGet(() -> createNewSentence(article, englishText, orderIndex));
 
-        sentence.setKoreanText(translatedText);
-        sentence.setTranslationStatus(Status.SUCCESS);
-        Sentence saved = sentenceRepository.save(sentence);
+        return processTranslation(sentence, englishText, articleId, orderIndex);
+    }
 
-        return SentenceResponseDto.builder()
-                .articleId(articleId)
-                .orderIndex(orderIndex)
-                .englishText(englishText)
-                .koreanText(translatedText)
-                .status(saved.getTranslationStatus())
-                .build();
+    private Sentence createNewSentence(Article article, String englishText, int orderIndex) {
+        return sentenceRepository.save(
+                Sentence.builder()
+                        .article(article)
+                        .translationStatus(Status.PENDING)
+                        .orderIndex(orderIndex)
+                        .englishText(englishText)
+                        .koreanText("")
+                        .build()
+        );
+    }
+
+    private SentenceResponseDto processTranslation(Sentence sentence, String englishText,
+                                                   Long articleId, int orderIndex) {
+
+        sentence.setTranslationStatus(Status.PROCESSING);
+        sentenceRepository.save(sentence);
+
+        try {
+            String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
+
+            sentence.setKoreanText(translatedText);
+            sentence.setTranslationStatus(Status.SUCCESS);
+            sentenceRepository.save(sentence);
+
+            return SentenceResponseDto.builder()
+                    .articleId(articleId)
+                    .orderIndex(orderIndex)
+                    .englishText(englishText)
+                    .koreanText(translatedText)
+                    .status(Status.SUCCESS)
+                    .build();
+        } catch (Exception e) {
+            sentence.setTranslationStatus(Status.FAILED);
+            sentenceRepository.save(sentence);
+
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw new TranslationInterruptedException();
+            }
+            if (e instanceof DeepLException) {
+                throw new TranslationFailedException();
+            }
+            throw new TranslationFailedException();
+        }
+
     }
 
     private List<String> splitIntoSentencesAdvanced(String text) {

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -45,7 +45,6 @@ public class SentenceService {
         return responses;
     }
 
-    @Transactional
     public SentenceResponseDto translateSingleSentence(Long articleId, Article article, String englishText,
                                                        int orderIndex) {
 

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -27,7 +27,7 @@ public class SentenceService {
     private final SentenceRepository sentenceRepository;
     private final ArticleRepository articleRepository;
 
-    private static final Integer MAX_RETRY_CNT = 3;
+    private static final int MAX_RETRY_CNT = 3;
 
     public List<SentenceResponseDto> translateOneParagraph(Long articleId) {
         Article article = articleRepository.findById(articleId)

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -115,7 +114,6 @@ public class SentenceService {
                         .status(Status.SUCCESS)
                         .build();
             } catch (Exception e) {
-                lastException = e;
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                     sentence.setTranslationStatus(Status.FAILED);
@@ -127,10 +125,6 @@ public class SentenceService {
         }
         sentence.setTranslationStatus(Status.FAILED);
         sentenceRepository.save(sentence);
-
-        if (lastException instanceof DeepLException) {
-            throw new TranslationFailedException();
-        }
         throw new TranslationFailedException();
     }
 

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -97,9 +97,11 @@ public class SentenceService {
         sentence.setTranslationStatus(Status.PROCESSING);
         sentenceRepository.save(sentence);
 
-        Exception lastException = null;
         for (int retryCnt = 0; retryCnt < MAX_RETRY_CNT; retryCnt++) {
             try {
+                if (retryCnt > 0) {
+                    Thread.sleep(500);
+                }
                 String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
 
                 sentence.setKoreanText(translatedText);
@@ -120,25 +122,11 @@ public class SentenceService {
                     sentenceRepository.save(sentence);
                     throw new TranslationInterruptedException();
                 }
-                waitBeforeRetry(retryCnt, sentence);
             }
         }
         sentence.setTranslationStatus(Status.FAILED);
         sentenceRepository.save(sentence);
         throw new TranslationFailedException();
-    }
-
-    private void waitBeforeRetry(int retryCnt, Sentence sentence) {
-        if (retryCnt < MAX_RETRY_CNT - 1) {
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                sentence.setTranslationStatus(Status.FAILED);
-                sentenceRepository.save(sentence);
-                throw new TranslationInterruptedException();
-            }
-        }
     }
 
     private List<String> splitIntoSentencesAdvanced(String text) {

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -75,6 +75,7 @@ public class SentenceService {
     }
 
     public void retryTranslation(Sentence sentence) throws DeepLException, InterruptedException {
+        sentence.incrementRetryCount();
         try {
             String translatedText = deepLClient
                     .translateText(sentence.getEnglishText(), null, "ko")

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -15,11 +15,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SentenceService {
     private final DeepLClient deepLClient;
     private final SentenceRepository sentenceRepository;
@@ -71,6 +73,24 @@ public class SentenceService {
                         .koreanText("")
                         .build()
         );
+    }
+
+    public void retryTranslation(Sentence sentence) throws DeepLException, InterruptedException {
+        try {
+            String translatedText = deepLClient
+                    .translateText(sentence.getEnglishText(), null, "ko")
+                    .getText();
+
+            sentence.setKoreanText(translatedText);
+            sentence.setTranslationStatus(Status.SUCCESS);
+
+        } catch (Exception e) {
+            log.warn("스케줄링 재처리 실패 - Sentence ID: {}, Error: {}",
+                    sentence.getId(), e.getMessage());
+            throw e;
+        } finally {
+            sentenceRepository.save(sentence);
+        }
     }
 
     private SentenceResponseDto processTranslation(Sentence sentence, String englishText,
@@ -157,7 +177,6 @@ public class SentenceService {
                 .orderIndex(sentence.getOrderIndex())
                 .englishText(sentence.getEnglishText())
                 .koreanText(sentence.getKoreanText())
-                .status(sentence.getTranslationStatus())
                 .status(sentence.getTranslationStatus())
                 .build();
     }

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -9,8 +9,10 @@ import com.newslit.backend.global.common.enums.Status;
 import com.newslit.backend.sentence.dto.SentenceResponseDto;
 import com.newslit.backend.sentence.exception.TranslationFailedException;
 import com.newslit.backend.sentence.exception.TranslationInterruptedException;
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,8 @@ public class SentenceService {
     private final DeepLClient deepLClient;
     private final SentenceRepository sentenceRepository;
     private final ArticleRepository articleRepository;
+
+    private static final Integer MAX_RETRY_CNT = 3;
 
     public List<SentenceResponseDto> translateOneParagraph(Long articleId) {
         Article article = articleRepository.findById(articleId)
@@ -71,38 +75,56 @@ public class SentenceService {
 
     private SentenceResponseDto processTranslation(Sentence sentence, String englishText,
                                                    Long articleId, int orderIndex) {
-
         sentence.setTranslationStatus(Status.PROCESSING);
         sentenceRepository.save(sentence);
 
-        try {
-            String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
+        Exception lastException = null;
+        for (int retryCnt = 0; retryCnt < MAX_RETRY_CNT; retryCnt++) {
+            try {
+                String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
 
-            sentence.setKoreanText(translatedText);
-            sentence.setTranslationStatus(Status.SUCCESS);
-            sentenceRepository.save(sentence);
+                sentence.setKoreanText(translatedText);
+                sentence.setTranslationStatus(Status.SUCCESS);
+                sentenceRepository.save(sentence);
 
-            return SentenceResponseDto.builder()
-                    .articleId(articleId)
-                    .orderIndex(orderIndex)
-                    .englishText(englishText)
-                    .koreanText(translatedText)
-                    .status(Status.SUCCESS)
-                    .build();
-        } catch (Exception e) {
-            sentence.setTranslationStatus(Status.FAILED);
-            sentenceRepository.save(sentence);
-
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw new TranslationInterruptedException();
+                return SentenceResponseDto.builder()
+                        .articleId(articleId)
+                        .orderIndex(orderIndex)
+                        .englishText(englishText)
+                        .koreanText(translatedText)
+                        .status(Status.SUCCESS)
+                        .build();
+            } catch (Exception e) {
+                lastException = e;
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    sentence.setTranslationStatus(Status.FAILED);
+                    sentenceRepository.save(sentence);
+                    throw new TranslationInterruptedException();
+                }
+                waitBeforeRetry(retryCnt, sentence);
             }
-            if (e instanceof DeepLException) {
-                throw new TranslationFailedException();
-            }
+        }
+        sentence.setTranslationStatus(Status.FAILED);
+        sentenceRepository.save(sentence);
+
+        if (lastException instanceof DeepLException) {
             throw new TranslationFailedException();
         }
+        throw new TranslationFailedException();
+    }
 
+    private void waitBeforeRetry(int retryCnt, Sentence sentence) {
+        if (retryCnt < MAX_RETRY_CNT - 1) {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                sentence.setTranslationStatus(Status.FAILED);
+                sentenceRepository.save(sentence);
+                throw new TranslationInterruptedException();
+            }
+        }
     }
 
     private List<String> splitIntoSentencesAdvanced(String text) {
@@ -115,11 +137,11 @@ public class SentenceService {
         // 구분선 제거
         text = text.replaceAll("(?m)^[\\-_=]{4,}\\s*$", "");
 
-        java.text.BreakIterator boundary = java.text.BreakIterator.getSentenceInstance(java.util.Locale.ENGLISH);
+        BreakIterator boundary = BreakIterator.getSentenceInstance(Locale.ENGLISH);
         boundary.setText(text);
 
         int start = boundary.first();
-        for (int end = boundary.next(); end != java.text.BreakIterator.DONE; start = end, end = boundary.next()) {
+        for (int end = boundary.next(); end != BreakIterator.DONE; start = end, end = boundary.next()) {
             String sentence = text.substring(start, end).trim();
             if (!sentence.isEmpty() && sentence.length() > 1) {
                 sentences.add(sentence);

--- a/backend/src/main/java/com/newslit/backend/sentence/exception/TranslationFailedException.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/exception/TranslationFailedException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.sentence.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class TranslationFailedException extends BusinessException {
+    public TranslationFailedException() {
+        super(ErrorCode.TRANSLATION_FAILED);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/sentence/exception/TranslationInterruptedException.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/exception/TranslationInterruptedException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.sentence.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class TranslationInterruptedException extends BusinessException {
+    public TranslationInterruptedException() {
+        super(ErrorCode.TRANSLATION_INTERRUPTED);
+    }
+}


### PR DESCRIPTION
## 🔍 변경 사항
번역 실패 시 즉시 재시도 및 스케줄링 재처리 기능을 추가

## 🔗 연결 이슈
Closes #6 

## 🛠️ 핵심 수정 사항 (How)

### 1. 즉시 재시도 로직 (실시간 API 호출)
- 번역 실패 시 최대 3회까지 즉시 재시도
- 재시도 간 0.5초 대기하여 일시적 네트워크 오류 대응
- InterruptedException 발생 시 재시도 없이 즉시 중단

### 2. 스케줄링 재처리 시스템
- 5분마다 FAILED 상태 문장들을 자동으로 재처리
- 각 문장별 독립적인 트랜잭션으로 실패 격리
- 최대 10회까지만 재처리하여 영구 실패 문장의 무한 재시도 방지
