### PR TITLE
#5 [FIX] Whisper API 문장 매핑 오류 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -6,9 +6,11 @@ import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.article.exception.ArticleNotFoundException;
 import com.newslit.backend.audio.dto.SegmentDto;
 import com.newslit.backend.audio.dto.WhisperResponseDto;
+import com.newslit.backend.audio.dto.WordDto;
 import com.newslit.backend.sentence.Sentence;
 import jakarta.transaction.Transactional;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -20,6 +22,7 @@ import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,12 +69,12 @@ public class AudioService {
 //        uploadMp3ToStorage(articleId, audioFile);
 
         try {
-            List<SegmentDto> segments = transcribe(audioFile);
+            List<WordDto> words = transcribe(audioFile, article);
             List<Sentence> sentences = article.getSentences().stream()
                     .sorted(Comparator.comparing(Sentence::getOrderIndex))
                     .collect(Collectors.toList());
 
-            matchAndSaveTimestamps(segments, sentences);
+            matchAndSaveTimestamps(words, sentences);
         } finally {
             audioFile.delete();
         }
@@ -79,7 +82,7 @@ public class AudioService {
     }
 
     private File downloadAudioFile(String url) throws IOException {
-        Request request = new Request.Builder()
+        Request request = new Builder()
                 .url(url)
                 .get()
                 .build();
@@ -92,59 +95,69 @@ public class AudioService {
             // 임시 파일 생성
             File tempFile = File.createTempFile("audio_", ".mp3");
             try (var inputStream = response.body().byteStream();
-                 var outputStream = new java.io.FileOutputStream(tempFile)) {
+                 var outputStream = new FileOutputStream(tempFile)) {
                 inputStream.transferTo(outputStream);
             }
             return tempFile;
         }
     }
 
-    private void matchAndSaveTimestamps(List<SegmentDto> segments, List<Sentence> sentences) {
-        int segmentStart = 0;
+    private void matchAndSaveTimestamps(List<WordDto> words, List<Sentence> sentences) {
+        int wordsStart = 0;
         for (Sentence sentence : sentences) {
             String englishText = normalizeText(sentence.getEnglishText());
-            System.out.println("CurSentence is " + englishText);
+            System.out.println("[CurSentence]" + englishText.replaceAll("\\s+", ""));
 
             boolean matched = false;
+            StringBuilder accumulated = new StringBuilder();
+            double startTime = -1;
 
-            for (int segmentIdx = segmentStart; segmentIdx < segments.size(); segmentIdx++) {
-                String segmentText = normalizeText(segments.get(segmentIdx).getText());
-                System.out.println("SegmentText is " + segmentText);
+            for (int wordsIdx = wordsStart; wordsIdx < words.size(); wordsIdx++) {
+                WordDto word = words.get(wordsIdx);
+                String normalizedWord = normalizeText(word.getWord());
 
-                if (englishText.equals(segmentText)) {
-                    sentence.setStartTime(segments.get(segmentIdx).getStart());
-                    sentence.setEndTime(segments.get(segmentIdx).getEnd());
+                accumulated.append(normalizedWord);
+
+                if (startTime == -1) {
+                    startTime = word.getStart();
+                }
+
+                if (englishText.replaceAll("\\s+", "").equals(accumulated.toString().replaceAll("\\s+", ""))) {
+                    System.out.println("[SegmentText] " + accumulated.toString().replaceAll("\\s+", ""));
+                    sentence.setStartTime(startTime);
+                    sentence.setEndTime(word.getEnd());
                     matched = true;
                     System.out.println("[SUCCESS] Matched!");
-                    segmentStart = segmentIdx + 1;
+                    wordsStart = wordsIdx + 1;
                     break;
                 }
             }
 
             if (!matched) {
-                System.out.println("[FAILED] " + englishText);
+                System.out.println("[FAILED] " + accumulated.toString().replaceAll("\\s+", ""));
             }
         }
     }
 
     private String normalizeText(String text) {
-        return text.trim()
+        return text.replaceAll("[^\\w\\s]", "")  // 특수문자 제거 (공백은 유지)
+                .replaceAll("\\s+", " ")       // 연속 공백을 하나로
                 .toLowerCase()
-                .replaceAll("[,.!?;:\"']", "")
-                .replaceAll("\\s+", " ");
+                .trim();
     }
 
-    public List<SegmentDto> transcribe(File audioFile) throws IOException {
+    public List<WordDto> transcribe(File audioFile, Article article) throws IOException {
         RequestBody requestBody = new MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("file", audioFile.getName(),
                         RequestBody.create(audioFile, AUDIO_MEDIA_TYPE))
                 .addFormDataPart("model", WHISPER_MODEL)
                 .addFormDataPart("response_format", RESPONSE_FORMAT)
-                .addFormDataPart("timestamp_granularities[]", TIMESTAMP_GRANULARITY)
+                .addFormDataPart("timestamp_granularities[]", "word")
+                .addFormDataPart("prompt", article.getOriginalText())
                 .build();
 
-        Request request = new Request.Builder()
+        Request request = new Builder()
                 .url(openAIUrl)
                 .addHeader("Authorization", "Bearer " + apiKey)
                 .post(requestBody)
@@ -159,7 +172,10 @@ public class AudioService {
                     response.body().string(),
                     WhisperResponseDto.class
             );
-            return mergeSegments(responseDto);
+
+            return responseDto.getWords();
+
+//            return mergeSegments(responseDto);
         }
     }
 
@@ -167,8 +183,8 @@ public class AudioService {
         List<SegmentDto> mergedSegments = new ArrayList<>();
         SegmentDto current = null;
 
-        for (SegmentDto segment : response.getSegments()) {
-            String text = segment.getText().trim();
+        for (WordDto segment : response.getWords()) {
+            String text = segment.getWord().trim();
 
             if (current == null) {
                 current = new SegmentDto();

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -4,15 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newslit.backend.article.Article;
 import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.article.exception.ArticleNotFoundException;
-import com.newslit.backend.audio.dto.SegmentDto;
 import com.newslit.backend.audio.dto.WhisperResponseDto;
 import com.newslit.backend.audio.dto.WordDto;
 import com.newslit.backend.sentence.Sentence;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
 import jakarta.transaction.Transactional;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,10 +39,8 @@ public class AudioService {
 
     private static final String WHISPER_MODEL = "whisper-1";
     private static final String RESPONSE_FORMAT = "verbose_json";
-    private static final String TIMESTAMP_GRANULARITY = "segment";
+    private static final String TIMESTAMP_GRANULARITY = "word";
     private static final MediaType AUDIO_MEDIA_TYPE = MediaType.parse("audio/mpeg");
-    private static final int LONG_SENTENCE_MATCH_LENGTH = 10;
-    private static final double SHORT_SENTENCE_MATCH_RATIO = 0.8;
 
     @Value("${openai.api-key}")
     private String apiKey;
@@ -54,7 +56,7 @@ public class AudioService {
 
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
-    //    private final ObjectStorage objectStorage;
+    private final ObjectStorage objectStorage;
     private final ArticleRepository articleRepository;
 
     @Transactional
@@ -65,8 +67,7 @@ public class AudioService {
 
         File audioFile = downloadAudioFile(article.getAudioDownloadLink());
 
-        //TODO : 추후 주석해제
-//        uploadMp3ToStorage(articleId, audioFile);
+        uploadMp3ToStorage(articleId, audioFile);
 
         try {
             List<WordDto> words = transcribe(audioFile, article);
@@ -105,45 +106,64 @@ public class AudioService {
     private void matchAndSaveTimestamps(List<WordDto> words, List<Sentence> sentences) {
         int wordsStart = 0;
         for (Sentence sentence : sentences) {
-            String englishText = normalizeText(sentence.getEnglishText());
-            System.out.println("[CurSentence]" + englishText.replaceAll("\\s+", ""));
+            int endIdx = getEndIdx(sentence, words, wordsStart);
 
-            boolean matched = false;
-            StringBuilder accumulated = new StringBuilder();
-            double startTime = -1;
+            sentence.setStartTime(words.get(wordsStart).getStart());
+            sentence.setEndTime(words.get(endIdx).getEnd());
 
-            for (int wordsIdx = wordsStart; wordsIdx < words.size(); wordsIdx++) {
-                WordDto word = words.get(wordsIdx);
-                String normalizedWord = normalizeText(word.getWord());
+            wordsStart = endIdx + 1;
+        }
+    }
 
-                accumulated.append(normalizedWord);
-
-                if (startTime == -1) {
-                    startTime = word.getStart();
-                }
-
-                if (englishText.replaceAll("\\s+", "").equals(accumulated.toString().replaceAll("\\s+", ""))) {
-                    System.out.println("[SegmentText] " + accumulated.toString().replaceAll("\\s+", ""));
-                    sentence.setStartTime(startTime);
-                    sentence.setEndTime(word.getEnd());
-                    matched = true;
-                    System.out.println("[SUCCESS] Matched!");
-                    wordsStart = wordsIdx + 1;
+    private int getEndIdx(Sentence sentence, List<WordDto> words, int start) {
+        int startIdx = start;
+        List<String> sentenceWords = List.of(sentence.getEnglishText().split(" "));
+        for (String word : sentenceWords) {
+            for (int i = startIdx; i < words.size(); i++) {
+                String curWord = words.get(i).getWord();
+                if (isSimilar(word, curWord)) {
+                    startIdx++;
                     break;
                 }
             }
-
-            if (!matched) {
-                System.out.println("[FAILED] " + accumulated.toString().replaceAll("\\s+", ""));
-            }
         }
+        return startIdx - 1;
     }
 
     private String normalizeText(String text) {
         return text.replaceAll("[^\\w\\s]", "")  // 특수문자 제거 (공백은 유지)
-                .replaceAll("\\s+", " ")       // 연속 공백을 하나로
+                .replaceAll("\\s+", "")       // 연속 공백을 하나로
                 .toLowerCase()
                 .trim();
+    }
+
+    private boolean isSimilar(String word1, String word2) {
+        word1 = normalizeText(word1);
+        word2 = normalizeText(word2);
+
+        if (word1.equals(word2)) {
+            return true;
+        }
+
+        int distance = levenshteinDistance(word1, word2);
+        int maxLen = Math.max(word1.length(), word2.length());
+        return distance <= (maxLen * 0.1);
+
+    }
+
+    public int levenshteinDistance(String word1, String word2) {
+        int[][] dp = new int[100][100];
+
+        for (int i = 1; i <= word1.length(); i++) {
+            for (int j = 1; j <= word2.length(); j++) {
+                if (word1.charAt(i - 1) == word2.charAt(j - 1)) {
+                    dp[i][j] = dp[i - 1][j - 1];
+                } else {
+                    dp[i][j] = Math.min(Math.min(dp[i - 1][j], dp[i][j - 1]), dp[i - 1][j - 1]) + 1;
+                }
+            }
+        }
+        return dp[word1.length()][word2.length()];
     }
 
     public List<WordDto> transcribe(File audioFile, Article article) throws IOException {
@@ -153,7 +173,7 @@ public class AudioService {
                         RequestBody.create(audioFile, AUDIO_MEDIA_TYPE))
                 .addFormDataPart("model", WHISPER_MODEL)
                 .addFormDataPart("response_format", RESPONSE_FORMAT)
-                .addFormDataPart("timestamp_granularities[]", "word")
+                .addFormDataPart("timestamp_granularities[]", TIMESTAMP_GRANULARITY)
                 .addFormDataPart("prompt", article.getOriginalText())
                 .build();
 
@@ -174,83 +194,47 @@ public class AudioService {
             );
 
             return responseDto.getWords();
-
-//            return mergeSegments(responseDto);
         }
     }
 
-    private List<SegmentDto> mergeSegments(WhisperResponseDto response) {
-        List<SegmentDto> mergedSegments = new ArrayList<>();
-        SegmentDto current = null;
 
-        for (WordDto segment : response.getWords()) {
-            String text = segment.getWord().trim();
+    public void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(ArticleNotFoundException::new);
 
-            if (current == null) {
-                current = new SegmentDto();
-                current.setId(mergedSegments.size());
-                current.setStart(segment.getStart());
-                current.setEnd(segment.getEnd());
-                current.setText(text);
-            } else {
-                current.setText(current.getText() + " " + text);
-                current.setEnd(segment.getEnd());
-            }
-
-            // 문장 끝 판단 (. ! ? 로 끝나면)
-            if (text.endsWith(".") || text.endsWith("!") || text.endsWith("?")) {
-                mergedSegments.add(current);
-                current = null;
-            }
+        if (!audioFile.exists()) {
+            throw new IOException("Audio file does not exist: " + audioFile.getPath());
         }
 
-        // 마지막 미완성 문장 처리
-        if (current != null) {
-            mergedSegments.add(current);
+        String objectName = article.getTitle()
+                .replaceAll("[^a-zA-Z0-9가-힣.-]", "_") + ".mp3";
+
+        // URL 인코딩 처리
+        String encodedObjectName = URLEncoder.encode(objectName, StandardCharsets.UTF_8)
+                .replace("+", "%20");
+
+        try (InputStream inputStream = new FileInputStream(audioFile)) {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .namespaceName(namespace)
+                    .bucketName(bucket)
+                    .objectName(objectName)
+                    .contentLength(audioFile.length())
+                    .contentType("audio/mpeg")
+                    .putObjectBody(inputStream)
+                    .build();
+
+            objectStorage.putObject(putRequest);
+
+            String audioUrl = String.format(
+                    "https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
+                    region,
+                    namespace,
+                    bucket,
+                    encodedObjectName
+            );
+
+            article.setAudioLink(audioUrl);
+            articleRepository.save(article);
         }
-        System.out.println("=============mergedSegments=====================");
-        mergedSegments.forEach(System.out::println);
-        System.out.println("=============mergedSegments=====================");
-        return mergedSegments;
     }
-
-//    public void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
-//        Article article = articleRepository.findById(articleId)
-//                .orElseThrow(ArticleNotFoundException::new);
-//
-//        if (!audioFile.exists()) {
-//            throw new IOException("Audio file does not exist: " + audioFile.getPath());
-//        }
-//
-//        String objectName = article.getTitle()
-//                .replaceAll("[^a-zA-Z0-9가-힣.-]", "_") + ".mp3";
-//
-//        // URL 인코딩 처리
-//        String encodedObjectName = URLEncoder.encode(objectName, StandardCharsets.UTF_8)
-//                .replace("+", "%20");
-//
-//        try (InputStream inputStream = new FileInputStream(audioFile)) {
-//            PutObjectRequest putRequest = PutObjectRequest.builder()
-//                    .namespaceName(namespace)
-//                    .bucketName(bucket)
-//                    .objectName(objectName)
-//                    .contentLength(audioFile.length())
-//                    .contentType("audio/mpeg")
-//                    .putObjectBody(inputStream)
-//                    .build();
-//
-//            objectStorage.putObject(putRequest);
-//
-//            String audioUrl = String.format(
-//                    "https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
-//                    region,
-//                    namespace,
-//                    bucket,
-//                    encodedObjectName
-//            );
-//
-//            article.setAudioLink(audioUrl);
-//            articleRepository.save(article);
-//        }
-//    }
 }

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -122,7 +122,7 @@ public class AudioService {
             for (int i = startIdx; i < words.size(); i++) {
                 String curWord = words.get(i).getWord();
                 if (isSimilar(word, curWord)) {
-                    startIdx++;
+                    startIdx = i + 1;
                     break;
                 }
             }

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -7,8 +7,6 @@ import com.newslit.backend.article.exception.ArticleNotFoundException;
 import com.newslit.backend.audio.dto.SegmentDto;
 import com.newslit.backend.audio.dto.WhisperResponseDto;
 import com.newslit.backend.sentence.Sentence;
-import com.oracle.bmc.objectstorage.ObjectStorage;
-import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
 import jakarta.transaction.Transactional;
 import java.io.File;
 import java.io.IOException;
@@ -26,10 +24,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 @Service
 @RequiredArgsConstructor
@@ -68,6 +62,7 @@ public class AudioService {
 
         File audioFile = downloadAudioFile(article.getAudioDownloadLink());
 
+        //TODO : 추후 주석해제
 //        uploadMp3ToStorage(articleId, audioFile);
 
         try {
@@ -105,21 +100,23 @@ public class AudioService {
     }
 
     private void matchAndSaveTimestamps(List<SegmentDto> segments, List<Sentence> sentences) {
+        int segmentStart = 0;
         for (Sentence sentence : sentences) {
             String englishText = normalizeText(sentence.getEnglishText());
             System.out.println("CurSentence is " + englishText);
 
             boolean matched = false;
 
-            for (SegmentDto segment : segments) {
-                String segmentText = normalizeText(segment.getText());
+            for (int segmentIdx = segmentStart; segmentIdx < segments.size(); segmentIdx++) {
+                String segmentText = normalizeText(segments.get(segmentIdx).getText());
                 System.out.println("SegmentText is " + segmentText);
 
                 if (isPartialMatch(englishText, segmentText)) {
-                    sentence.setStartTime(segment.getStart());
-                    sentence.setEndTime(segment.getEnd());
+                    sentence.setStartTime(segments.get(segmentIdx).getStart());
+                    sentence.setEndTime(segments.get(segmentIdx).getEnd());
                     matched = true;
                     System.out.println("[SUCCESS] Matched!");
+                    segmentStart = segmentIdx + 1;
                     break;
                 }
             }

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -131,8 +131,8 @@ public class AudioService {
     }
 
     private String normalizeText(String text) {
-        return text.replaceAll("[^\\w\\s]", "")  // 특수문자 제거 (공백은 유지)
-                .replaceAll("\\s+", "")       // 연속 공백을 하나로
+        return text.replaceAll("[^\\w\\s]", "")
+                .replaceAll("\\s+", "")
                 .toLowerCase()
                 .trim();
     }

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -107,6 +107,10 @@ public class AudioService {
         int wordsStart = 0;
         for (Sentence sentence : sentences) {
             int endIdx = getEndIdx(sentence, words, wordsStart);
+            
+            if (endIdx < wordsStart || endIdx >= words.size()) {
+                continue;
+            }
 
             sentence.setStartTime(words.get(wordsStart).getStart());
             sentence.setEndTime(words.get(endIdx).getEnd());

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -57,7 +57,7 @@ public class AudioService {
 
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
-    private final ObjectStorage objectStorage;
+    //    private final ObjectStorage objectStorage;
     private final ArticleRepository articleRepository;
 
     @Transactional
@@ -68,7 +68,7 @@ public class AudioService {
 
         File audioFile = downloadAudioFile(article.getAudioDownloadLink());
 
-        uploadMp3ToStorage(articleId, audioFile);
+//        uploadMp3ToStorage(articleId, audioFile);
 
         try {
             List<SegmentDto> segments = transcribe(audioFile);
@@ -106,20 +106,35 @@ public class AudioService {
 
     private void matchAndSaveTimestamps(List<SegmentDto> segments, List<Sentence> sentences) {
         for (Sentence sentence : sentences) {
-            String englishText = sentence.getEnglishText().trim().toLowerCase();
+            String englishText = normalizeText(sentence.getEnglishText());
+            System.out.println("CurSentence is " + englishText);
 
-            // 매칭되는 segment 찾기
+            boolean matched = false;
+
             for (SegmentDto segment : segments) {
-                String segmentText = segment.getText().trim().toLowerCase();
+                String segmentText = normalizeText(segment.getText());
+                System.out.println("SegmentText is " + segmentText);
 
-                // 앞부분 일치 확인 (최소 10자 이상 일치하거나, 짧은 문장은 80% 이상 일치)
                 if (isPartialMatch(englishText, segmentText)) {
                     sentence.setStartTime(segment.getStart());
                     sentence.setEndTime(segment.getEnd());
+                    matched = true;
+                    System.out.println("[SUCCESS] Matched!");
                     break;
                 }
             }
+
+            if (!matched) {
+                System.out.println("[FAILED] " + englishText);
+            }
         }
+    }
+
+    private String normalizeText(String text) {
+        return text.trim()
+                .toLowerCase()
+                .replaceAll("[,.!?;:\"']", "")
+                .replaceAll("\\s+", " ");
     }
 
     private boolean isPartialMatch(String sentenceText, String segmentText) {
@@ -198,46 +213,49 @@ public class AudioService {
         if (current != null) {
             mergedSegments.add(current);
         }
+        System.out.println("=============mergedSegments=====================");
+        mergedSegments.forEach(System.out::println);
+        System.out.println("=============mergedSegments=====================");
         return mergedSegments;
     }
 
-    public void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
-        Article article = articleRepository.findById(articleId)
-                .orElseThrow(ArticleNotFoundException::new);
-
-        if (!audioFile.exists()) {
-            throw new IOException("Audio file does not exist: " + audioFile.getPath());
-        }
-
-        String objectName = article.getTitle()
-                .replaceAll("[^a-zA-Z0-9가-힣.-]", "_") + ".mp3";
-
-        // URL 인코딩 처리
-        String encodedObjectName = URLEncoder.encode(objectName, StandardCharsets.UTF_8)
-                .replace("+", "%20");
-
-        try (InputStream inputStream = new FileInputStream(audioFile)) {
-            PutObjectRequest putRequest = PutObjectRequest.builder()
-                    .namespaceName(namespace)
-                    .bucketName(bucket)
-                    .objectName(objectName)
-                    .contentLength(audioFile.length())
-                    .contentType("audio/mpeg")
-                    .putObjectBody(inputStream)
-                    .build();
-
-            objectStorage.putObject(putRequest);
-
-            String audioUrl = String.format(
-                    "https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
-                    region,
-                    namespace,
-                    bucket,
-                    encodedObjectName
-            );
-
-            article.setAudioLink(audioUrl);
-            articleRepository.save(article);
-        }
-    }
+//    public void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
+//        Article article = articleRepository.findById(articleId)
+//                .orElseThrow(ArticleNotFoundException::new);
+//
+//        if (!audioFile.exists()) {
+//            throw new IOException("Audio file does not exist: " + audioFile.getPath());
+//        }
+//
+//        String objectName = article.getTitle()
+//                .replaceAll("[^a-zA-Z0-9가-힣.-]", "_") + ".mp3";
+//
+//        // URL 인코딩 처리
+//        String encodedObjectName = URLEncoder.encode(objectName, StandardCharsets.UTF_8)
+//                .replace("+", "%20");
+//
+//        try (InputStream inputStream = new FileInputStream(audioFile)) {
+//            PutObjectRequest putRequest = PutObjectRequest.builder()
+//                    .namespaceName(namespace)
+//                    .bucketName(bucket)
+//                    .objectName(objectName)
+//                    .contentLength(audioFile.length())
+//                    .contentType("audio/mpeg")
+//                    .putObjectBody(inputStream)
+//                    .build();
+//
+//            objectStorage.putObject(putRequest);
+//
+//            String audioUrl = String.format(
+//                    "https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
+//                    region,
+//                    namespace,
+//                    bucket,
+//                    encodedObjectName
+//            );
+//
+//            article.setAudioLink(audioUrl);
+//            articleRepository.save(article);
+//        }
+//    }
 }

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -152,7 +152,7 @@ public class AudioService {
     }
 
     private int levenshteinDistance(String word1, String word2) {
-        int[][] dp = new int[100][100];
+        int[][] dp = new int[word1.length() + 1][word2.length() + 1];
 
         for (int i = 1; i <= word1.length(); i++) {
             for (int j = 1; j <= word2.length(); j++) {

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -151,7 +151,7 @@ public class AudioService {
 
     }
 
-    public int levenshteinDistance(String word1, String word2) {
+    private int levenshteinDistance(String word1, String word2) {
         int[][] dp = new int[100][100];
 
         for (int i = 1; i <= word1.length(); i++) {
@@ -166,7 +166,7 @@ public class AudioService {
         return dp[word1.length()][word2.length()];
     }
 
-    public List<WordDto> transcribe(File audioFile, Article article) throws IOException {
+    private List<WordDto> transcribe(File audioFile, Article article) throws IOException {
         RequestBody requestBody = new MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("file", audioFile.getName(),
@@ -198,7 +198,7 @@ public class AudioService {
     }
 
 
-    public void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
+    private void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(ArticleNotFoundException::new);
 

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -111,7 +111,7 @@ public class AudioService {
                 String segmentText = normalizeText(segments.get(segmentIdx).getText());
                 System.out.println("SegmentText is " + segmentText);
 
-                if (isPartialMatch(englishText, segmentText)) {
+                if (englishText.equals(segmentText)) {
                     sentence.setStartTime(segments.get(segmentIdx).getStart());
                     sentence.setEndTime(segments.get(segmentIdx).getEnd());
                     matched = true;
@@ -132,24 +132,6 @@ public class AudioService {
                 .toLowerCase()
                 .replaceAll("[,.!?;:\"']", "")
                 .replaceAll("\\s+", " ");
-    }
-
-    private boolean isPartialMatch(String sentenceText, String segmentText) {
-        int minMatchLength = LONG_SENTENCE_MATCH_LENGTH;
-
-        // 둘 중 짧은 문장 기준
-        int minLength = Math.min(sentenceText.length(), segmentText.length());
-
-        if (minLength < minMatchLength) {
-            // 짧은 문장: 80% 이상 일치
-            int matchLength = (int) (minLength * SHORT_SENTENCE_MATCH_RATIO);
-            return sentenceText.startsWith(segmentText.substring(0, Math.min(matchLength, segmentText.length())))
-                    || segmentText.startsWith(sentenceText.substring(0, Math.min(matchLength, sentenceText.length())));
-        } else {
-            // 긴 문장: 앞부분 10자 이상 일치
-            return sentenceText.startsWith(segmentText.substring(0, minMatchLength))
-                    || segmentText.startsWith(sentenceText.substring(0, minMatchLength));
-        }
     }
 
     public List<SegmentDto> transcribe(File audioFile) throws IOException {

--- a/backend/src/main/java/com/newslit/backend/audio/dto/WordDto.java
+++ b/backend/src/main/java/com/newslit/backend/audio/dto/WordDto.java
@@ -1,14 +1,12 @@
 package com.newslit.backend.audio.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.List;
 import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class WhisperResponseDto {
-    private String text;
-    private String language;
-    private Double duration;
-    private List<WordDto> words;
+public class WordDto {
+    private String word;
+    private Double start;
+    private Double end;
 }

--- a/backend/src/test/java/com/newslit/backend/audio/AudioServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/audio/AudioServiceTest.java
@@ -1,0 +1,29 @@
+package com.newslit.backend.audio;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.transaction.Transactional;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Slf4j
+class AudioServiceTest {
+    @Autowired
+    private AudioService audioService;
+
+    @Test
+    void audio_test() {
+        try {
+            log.info("article {} 타임스탬프 시작", 50);
+            audioService.saveTimeStamp(50L);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 🔍  Whisper API 문장 매핑 오류 수정

## 🔗 연결 이슈: 
Closes #5 

## 🛠️ 핵심 수정 사항 (How)

- 문장 단위 비교 → 단어 단위 비교로 변경하여 STT 문장 분리 불일치 문제 해결
- 이중 for문 O(N×M) → Two-pointer 방식 O(N+M)으로 매칭 효율 개선
- 앞글자 단순 비교 → Levenshtein Distance 기반 유사도 판정 도입 (theater/theatre 등 오차 허용)
- Whisper 프롬프트에 기사 전문을 포함시켜 숫자(5→five) 등 변환 불일치 감소

