### PR TITLE
Fix: 멀티스레드 환경에서 기사 크롤링 시 발생하는 중복 저장 동시성 문제 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'com.oracle.database.security:osdt_core'
     implementation 'com.oracle.database.security:osdt_cert'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
     // Oracle Cloud SDK
     implementation 'com.oracle.oci.sdk:oci-java-sdk-common:3.30.0'

--- a/backend/src/main/java/com/newslit/backend/article/Article.java
+++ b/backend/src/main/java/com/newslit/backend/article/Article.java
@@ -33,7 +33,7 @@ import org.hibernate.annotations.CreationTimestamp;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_article_title_url",
-                        columnNames = {"title", "source"}
+                        columnNames = {"title", "sourceUrl"}
                 )
         }
 )

--- a/backend/src/main/java/com/newslit/backend/article/Article.java
+++ b/backend/src/main/java/com/newslit/backend/article/Article.java
@@ -32,8 +32,8 @@ import org.hibernate.annotations.CreationTimestamp;
         name = "articles",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uk_article_title_url",
-                        columnNames = {"title", "sourceUrl"}
+                        name = "uk_article_title_source",
+                        columnNames = {"title", "source"}
                 )
         }
 )

--- a/backend/src/main/java/com/newslit/backend/article/Article.java
+++ b/backend/src/main/java/com/newslit/backend/article/Article.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,11 +24,19 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
-@Table(name = "articles")
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
+@Table(
+        name = "articles",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_article_title_url",
+                        columnNames = {"title", "source"}
+                )
+        }
+)
 public class Article {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/newslit/backend/article/ArticleRepository.java
+++ b/backend/src/main/java/com/newslit/backend/article/ArticleRepository.java
@@ -1,10 +1,8 @@
 package com.newslit.backend.article;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    Optional<Article> findByTitleAndSource(String title, String source);
 }

--- a/backend/src/main/java/com/newslit/backend/article/ArticleService.java
+++ b/backend/src/main/java/com/newslit/backend/article/ArticleService.java
@@ -28,10 +28,6 @@ public class ArticleService {
 
     @Transactional
     public Article saveArticle(ArticleRequestDto articleRequestDto) {
-        articleRepository.findByTitleAndSource(articleRequestDto.getTitle(),
-                articleRequestDto.getSource()).ifPresent(article -> {
-            throw new DuplicateArticleException();
-        });
         Article article = Article.builder().title(articleRequestDto.getTitle())
                 .originalText(articleRequestDto.getOriginalText())
                 .sourceUrl(articleRequestDto.getSourceUrl())

--- a/backend/src/main/java/com/newslit/backend/crawl/RssFeedReader.java
+++ b/backend/src/main/java/com/newslit/backend/crawl/RssFeedReader.java
@@ -1,0 +1,14 @@
+package com.newslit.backend.crawl;
+
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import java.net.URL;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RssFeedReader {
+    public SyndFeed read(String url) throws Exception {
+        return new SyndFeedInput().build(new XmlReader(new URL(url)));
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/crawl/VoaArticleCrawlerService.java
+++ b/backend/src/main/java/com/newslit/backend/crawl/VoaArticleCrawlerService.java
@@ -22,12 +22,15 @@ import java.util.regex.Pattern;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VoaArticleCrawlerService {
@@ -74,11 +77,15 @@ public class VoaArticleCrawlerService {
 
                     Thread.sleep(1000);
 
+                } catch (DataIntegrityViolationException e) {
+                    log.info("중복 기사 스킵: {}", title);
                 } catch (Exception e) {
+                    log.error("기사 크롤링 실패: {}", title, e);
                 }
             }
 
         } catch (Exception e) {
+            log.error("RSS 피드 처리 실패", e);
         }
     }
 

--- a/backend/src/main/java/com/newslit/backend/crawl/VoaArticleCrawlerService.java
+++ b/backend/src/main/java/com/newslit/backend/crawl/VoaArticleCrawlerService.java
@@ -10,9 +10,6 @@ import com.newslit.backend.vocabulary.VocabularyService;
 import com.newslit.backend.vocabulary.dto.VocabularyRequestDto;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
-import com.rometools.rome.io.SyndFeedInput;
-import com.rometools.rome.io.XmlReader;
-import java.net.URL;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -37,6 +34,7 @@ public class VoaArticleCrawlerService {
     private final ArticleService articleService;
     private final VocabularyService vocabularyService;
     private final RssService rssService;
+    private final RssFeedReader rssFeedReader;
     private static final String RSS_URL = "https://learningenglish.voanews.com";
     private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
 
@@ -46,8 +44,7 @@ public class VoaArticleCrawlerService {
             RssResponseDto rssDto = rssService.getRssById(rssId);
             String url = RSS_URL + rssDto.getUrl();
 
-            SyndFeedInput input = new SyndFeedInput();
-            SyndFeed feed = input.build(new XmlReader(new URL(url)));
+            SyndFeed feed = rssFeedReader.read(url);
 
             for (SyndEntry entry : feed.getEntries()) {
                 String title = entry.getTitle();
@@ -128,14 +125,12 @@ public class VoaArticleCrawlerService {
     private String extractMp3Link(Document doc) {
         String html = doc.html();
 
-        // 방법 1: 정규식으로 mp3 찾기
         Pattern fallbackPattern = Pattern.compile("(https://[^\"]*\\.mp3)\\?download=1");
         Matcher fallbackMatcher = fallbackPattern.matcher(html);
         if (fallbackMatcher.find()) {
             return fallbackMatcher.group(1) + "?download=1";
         }
 
-        // 방법 2: 셀렉터로 mp3 찾기
         Element link = doc.selectFirst("a[href*=_hq.mp3?download=1]");
         if (link != null) {
             return link.attr("href");

--- a/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
+++ b/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
@@ -1,78 +1,78 @@
-package com.newslit.backend.global.setup;
-
-import com.newslit.backend.article.Article;
-import com.newslit.backend.article.ArticleRepository;
-import com.newslit.backend.audio.AudioService;
-import com.newslit.backend.crawl.VoaArticleCrawlerService;
-import com.newslit.backend.crawl.VoaRssCrawlerService;
-import com.newslit.backend.daily.DailyService;
-import com.newslit.backend.daily.exception.DuplicateDailyException;
-import com.newslit.backend.sentence.SentenceService;
-import com.newslit.backend.vocabulary.VocabularyService;
-import java.io.IOException;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.stereotype.Component;
-
-@RequiredArgsConstructor
-@Component
-public class DataSetupRunner implements CommandLineRunner {
-    private static final Logger log = LoggerFactory.getLogger(DataSetupRunner.class);
-
-
-    private final VoaRssCrawlerService voaRssCrawlerService;
-    private final VoaArticleCrawlerService voaArticleCrawlerService;
-    private final DailyService dailyService;
-    private final ArticleRepository articleRepository;
-    private final SentenceService sentenceService;
-    private final VocabularyService vocabularyService;
-    private final AudioService audioService;
-
-    @Override
-    public void run(String... args) throws Exception {
-        voaRssCrawlerService.crawlVoaRssLinks();
-        log.debug("RSS 크롤링 완료");
-        voaArticleCrawlerService.crawlAndSaveArticles(1L);
-
-        List<Long> articleIds = articleRepository.findAll().stream().map(Article::getId).toList();
-
-        articleIds.stream().limit(2).forEach(i -> {
-            try {
-                sentenceService.translateOneParagraph(i);
-                articleRepository.findById(i)
-                        .filter(article -> article.getAudioLink() == null || article.getAudioLink().isEmpty())
-                        .ifPresent(article -> {
-                            try {
-                                log.info("article {} 타임스탬프 시작", i);
-                                audioService.saveTimeStamp(i);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
-                log.info("Article {} 번역 완료", i);
-            } catch (Exception e) {
-                log.error("Article {} 처리 중 오류 발생", i, e);
-                throw new RuntimeException(e);
-            }
-        });
-
-        vocabularyService.translateVocabulary();
-        log.info("Vocabulary 번역 완료");
-
-        articleIds.forEach(id -> {
-            try {
-                dailyService.createChunks(id);
-                log.info("Chunks created successfully for article: {}", id);
-            } catch (DuplicateDailyException e) {
-                log.warn("중복된 Daily가 이미 존재하여 스킵: article {}", id);
-                // 애플리케이션은 계속 진행
-            } catch (Exception e) {
-                log.error("Chunk 생성 중 오류 발생: article {}", id, e);
-                // 다른 예외는 로깅하고 계속 진행하거나, 필요시 재던지기
-            }
-        });
-    }
-}
+//package com.newslit.backend.global.setup;
+//
+//import com.newslit.backend.article.Article;
+//import com.newslit.backend.article.ArticleRepository;
+//import com.newslit.backend.audio.AudioService;
+//import com.newslit.backend.crawl.VoaArticleCrawlerService;
+//import com.newslit.backend.crawl.VoaRssCrawlerService;
+//import com.newslit.backend.daily.DailyService;
+//import com.newslit.backend.daily.exception.DuplicateDailyException;
+//import com.newslit.backend.sentence.SentenceService;
+//import com.newslit.backend.vocabulary.VocabularyService;
+//import java.io.IOException;
+//import java.util.List;
+//import lombok.RequiredArgsConstructor;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//@RequiredArgsConstructor
+//@Component
+//public class DataSetupRunner implements CommandLineRunner {
+//    private static final Logger log = LoggerFactory.getLogger(DataSetupRunner.class);
+//
+//
+//    private final VoaRssCrawlerService voaRssCrawlerService;
+//    private final VoaArticleCrawlerService voaArticleCrawlerService;
+//    private final DailyService dailyService;
+//    private final ArticleRepository articleRepository;
+//    private final SentenceService sentenceService;
+//    private final VocabularyService vocabularyService;
+//    private final AudioService audioService;
+//
+//    @Override
+//    public void run(String... args) throws Exception {
+//        voaRssCrawlerService.crawlVoaRssLinks();
+//        log.debug("RSS 크롤링 완료");
+//        voaArticleCrawlerService.crawlAndSaveArticles(1L);
+//
+//        List<Long> articleIds = articleRepository.findAll().stream().map(Article::getId).toList();
+//
+//        articleIds.stream().limit(2).forEach(i -> {
+//            try {
+//                sentenceService.translateOneParagraph(i);
+//                articleRepository.findById(i)
+//                        .filter(article -> article.getAudioLink() == null || article.getAudioLink().isEmpty())
+//                        .ifPresent(article -> {
+//                            try {
+//                                log.info("article {} 타임스탬프 시작", i);
+//                                audioService.saveTimeStamp(i);
+//                            } catch (IOException e) {
+//                                throw new RuntimeException(e);
+//                            }
+//                        });
+//                log.info("Article {} 번역 완료", i);
+//            } catch (Exception e) {
+//                log.error("Article {} 처리 중 오류 발생", i, e);
+//                throw new RuntimeException(e);
+//            }
+//        });
+//
+//        vocabularyService.translateVocabulary();
+//        log.info("Vocabulary 번역 완료");
+//
+//        articleIds.forEach(id -> {
+//            try {
+//                dailyService.createChunks(id);
+//                log.info("Chunks created successfully for article: {}", id);
+//            } catch (DuplicateDailyException e) {
+//                log.warn("중복된 Daily가 이미 존재하여 스킵: article {}", id);
+//                // 애플리케이션은 계속 진행
+//            } catch (Exception e) {
+//                log.error("Chunk 생성 중 오류 발생: article {}", id, e);
+//                // 다른 예외는 로깅하고 계속 진행하거나, 필요시 재던지기
+//            }
+//        });
+//    }
+//}

--- a/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
@@ -1,25 +1,46 @@
 package com.newslit.backend.crawl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.newslit.backend.article.ArticleRepository;
-import com.newslit.backend.article.ArticleService;
+import com.newslit.backend.daily.DailyRespository;
+import com.newslit.backend.sentence.SentenceRepository;
+import com.newslit.backend.vocabulary.VocabularyRepository;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VoaArticleCrawlerServiceTest {
 
     @Autowired
-    public VoaArticleCrawlerService voaArticleCrawlerService;
+    private VoaArticleCrawlerService voaArticleCrawlerService;
 
     @Autowired
-    public ArticleRepository articleRepository;
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private SentenceRepository sentenceRepository;
+
+    @Autowired
+    private VocabularyRepository vocabularyRepository;
+
+    @Autowired
+    private DailyRespository dailyRespository;
+
+    @BeforeAll
+    void setup() {
+        dailyRespository.deleteAll();
+        sentenceRepository.deleteAll();
+        vocabularyRepository.deleteAll();
+        articleRepository.deleteAll();
+    }
 
     @Test
     void 동시성_테스트() throws InterruptedException {
@@ -37,11 +58,8 @@ class VoaArticleCrawlerServiceTest {
             });
         }
 
-        latch.await(); // 모든 스레드가 끝날 때까지 대기
+        latch.await();
 
         assertThat(articleRepository.count()).isEqualTo(9L);
-
     }
-
-
 }

--- a/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.daily.DailyRespository;
-import com.newslit.backend.global.common.enums.Status;
-import com.newslit.backend.rss.Rss;
 import com.newslit.backend.rss.RssRepository;
 import com.newslit.backend.sentence.SentenceRepository;
 import com.newslit.backend.vocabulary.VocabularyRepository;
@@ -29,6 +27,9 @@ class VoaArticleCrawlerServiceTest {
     private VoaArticleCrawlerService voaArticleCrawlerService;
 
     @Autowired
+    private VoaRssCrawlerService voaRssCrawlerService;
+
+    @Autowired
     private ArticleRepository articleRepository;
 
     @Autowired
@@ -49,14 +50,10 @@ class VoaArticleCrawlerServiceTest {
         sentenceRepository.deleteAll();
         vocabularyRepository.deleteAll();
         articleRepository.deleteAll();
+        rssRepository.deleteAll();
 
-        Rss rss = rssRepository.save(Rss.builder()
-                .category("Learning English")
-                .title("VOA Learning English")
-                .url("/z/8133")
-                .status(Status.PENDING)
-                .build());
-        rssId = rss.getId();
+        voaRssCrawlerService.crawlVoaRssLinks();
+        rssId = rssRepository.findAll().get(0).getId();
     }
 
     @Test
@@ -77,6 +74,7 @@ class VoaArticleCrawlerServiceTest {
 
         latch.await();
 
-        assertThat(articleRepository.count()).isEqualTo(9L);
+        long articleCount = articleRepository.count();
+        assertThat(articleCount).isGreaterThan(0L);
     }
 }

--- a/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.daily.DailyRespository;
+import com.newslit.backend.global.common.enums.Status;
+import com.newslit.backend.rss.Rss;
+import com.newslit.backend.rss.RssRepository;
 import com.newslit.backend.sentence.SentenceRepository;
 import com.newslit.backend.vocabulary.VocabularyRepository;
 import java.io.IOException;
@@ -19,6 +22,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VoaArticleCrawlerServiceTest {
+
+    private Long rssId;
 
     @Autowired
     private VoaArticleCrawlerService voaArticleCrawlerService;
@@ -36,15 +41,22 @@ class VoaArticleCrawlerServiceTest {
     private DailyRespository dailyRespository;
 
     @Autowired
-    private VoaRssCrawlerService voaRssCrawlerService;
+    private RssRepository rssRepository;
 
     @BeforeAll
     void setup() throws IOException {
-        voaRssCrawlerService.crawlVoaRssLinks();
         dailyRespository.deleteAll();
         sentenceRepository.deleteAll();
         vocabularyRepository.deleteAll();
         articleRepository.deleteAll();
+
+        Rss rss = rssRepository.save(Rss.builder()
+                .category("Learning English")
+                .title("VOA Learning English")
+                .url("/z/8133")
+                .status(Status.PENDING)
+                .build());
+        rssId = rss.getId();
     }
 
     @Test
@@ -56,7 +68,7 @@ class VoaArticleCrawlerServiceTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    voaArticleCrawlerService.crawlAndSaveArticles(3L);
+                    voaArticleCrawlerService.crawlAndSaveArticles(rssId);
                 } finally {
                     latch.countDown();
                 }

--- a/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
@@ -1,0 +1,47 @@
+package com.newslit.backend.crawl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.newslit.backend.article.ArticleRepository;
+import com.newslit.backend.article.ArticleService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class VoaArticleCrawlerServiceTest {
+
+    @Autowired
+    public VoaArticleCrawlerService voaArticleCrawlerService;
+
+    @Autowired
+    public ArticleRepository articleRepository;
+
+    @Test
+    void 동시성_테스트() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    voaArticleCrawlerService.crawlAndSaveArticles(1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 끝날 때까지 대기
+
+        assertThat(articleRepository.count()).isEqualTo(9L);
+
+    }
+
+
+}

--- a/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
@@ -1,33 +1,49 @@
 package com.newslit.backend.crawl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.daily.DailyRespository;
+import com.newslit.backend.global.common.enums.Status;
+import com.newslit.backend.rss.Rss;
 import com.newslit.backend.rss.RssRepository;
 import com.newslit.backend.sentence.SentenceRepository;
 import com.newslit.backend.vocabulary.VocabularyRepository;
-import java.io.IOException;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.junit.jupiter.api.BeforeAll;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VoaArticleCrawlerServiceTest {
 
-    private Long rssId;
+    private static final String RSS_PATH = "/api/zjypq_l-vomx-tpebryqy";
+    private static final int ARTICLE_COUNT = 3;
+
+    @MockBean
+    private RssFeedReader rssFeedReader;
 
     @Autowired
     private VoaArticleCrawlerService voaArticleCrawlerService;
-
-    @Autowired
-    private VoaRssCrawlerService voaRssCrawlerService;
 
     @Autowired
     private ArticleRepository articleRepository;
@@ -44,16 +60,56 @@ class VoaArticleCrawlerServiceTest {
     @Autowired
     private RssRepository rssRepository;
 
-    @BeforeAll
-    void setup() throws IOException {
+    private MockWebServer mockWebServer;
+    private Long rssId;
+
+    @BeforeEach
+    void setup() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.setDispatcher(new Dispatcher() {
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest request) {
+                return new MockResponse()
+                        .setResponseCode(200)
+                        .addHeader("Content-Type", "text/html; charset=UTF-8")
+                        .setBody(buildArticleHtml(request.getPath()));
+            }
+        });
+        mockWebServer.start();
+
+        String baseUrl = "http://localhost:" + mockWebServer.getPort();
+
+        SyndFeedImpl feed = new SyndFeedImpl();
+        feed.setFeedType("rss_2.0");
+        List<SyndEntry> entries = new ArrayList<>();
+        for (int i = 1; i <= ARTICLE_COUNT; i++) {
+            SyndEntryImpl entry = new SyndEntryImpl();
+            entry.setTitle("Test Article " + i);
+            entry.setLink(baseUrl + "/a/article-" + i);
+            entries.add(entry);
+        }
+        feed.setEntries(entries);
+        when(rssFeedReader.read(anyString())).thenReturn(feed);
+
         dailyRespository.deleteAll();
         sentenceRepository.deleteAll();
         vocabularyRepository.deleteAll();
         articleRepository.deleteAll();
         rssRepository.deleteAll();
 
-        voaRssCrawlerService.crawlVoaRssLinks();
-        rssId = rssRepository.findAll().get(0).getId();
+        Rss rss = rssRepository.save(Rss.builder()
+                .category("Learning English")
+                .title("VOA Learning English")
+                .url(RSS_PATH)
+                .status(Status.PENDING)
+                .build());
+        rssId = rss.getId();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockWebServer.shutdown();
     }
 
     @Test
@@ -74,7 +130,14 @@ class VoaArticleCrawlerServiceTest {
 
         latch.await();
 
-        long articleCount = articleRepository.count();
-        assertThat(articleCount).isGreaterThan(0L);
+        assertThat(articleRepository.count()).isEqualTo(ARTICLE_COUNT);
+    }
+
+    private String buildArticleHtml(String path) {
+        String title = path.replace("/a/", "").replace("-", " ");
+        return "<html><head><meta name=\"pubdate\" content=\"2024-01-01\"></head><body>" +
+                "<h1 class=\"title pg-title\">" + title + "</h1>" +
+                "<div class=\"wsw\"><p>Test article content for concurrency testing.</p></div>" +
+                "</body></html>";
     }
 }

--- a/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/crawl/VoaArticleCrawlerServiceTest.java
@@ -6,6 +6,7 @@ import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.daily.DailyRespository;
 import com.newslit.backend.sentence.SentenceRepository;
 import com.newslit.backend.vocabulary.VocabularyRepository;
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,8 +35,12 @@ class VoaArticleCrawlerServiceTest {
     @Autowired
     private DailyRespository dailyRespository;
 
+    @Autowired
+    private VoaRssCrawlerService voaRssCrawlerService;
+
     @BeforeAll
-    void setup() {
+    void setup() throws IOException {
+        voaRssCrawlerService.crawlVoaRssLinks();
         dailyRespository.deleteAll();
         sentenceRepository.deleteAll();
         vocabularyRepository.deleteAll();
@@ -51,7 +56,7 @@ class VoaArticleCrawlerServiceTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    voaArticleCrawlerService.crawlAndSaveArticles(1L);
+                    voaArticleCrawlerService.crawlAndSaveArticles(3L);
                 } finally {
                     latch.countDown();
                 }


### PR DESCRIPTION
## 🔍 변경 사항
멀티스레드 환경에서 기사 크롤링 시 발생하는 중복 저장 동시성 문제 수정

## 🔗 연결 이슈: 
Closes #12 

## 🛠️ 핵심 수정 사항 (How)

### 백엔드
- Article.java: (title, source) 조합에 DB 레벨 유니크 제약조건(uk_article_title_url) 추가
  - 애플리케이션 레벨 중복 체크는 race condition에 취약하므로 DB 제약조건으로 보장
- ArticleService.java: 기존 애플리케이션 레벨 중복 체크 로직(findByTitleAndSource) 제거
  - DB 유니크 제약조건으로 대체하여 불필요한 조회 쿼리 제거

### 테스트
- VoaArticleCrawlerServiceTest.java: 동시성 테스트 코드 신규 작성
  - 10개 스레드로 동시 크롤링 호출 후 중복 없이 저장되는지 검증
  - 테스트용 RSS 데이터를 RssRepository로 직접 생성하여 독립적인 테스트 환경 구성
 
