### PR TITLE
Fix: 외부 API 호출 시 별도 쓰레드풀 사용 및 음성 API 관련 로직 트랜잭션 분리

### DIFF
--- a/backend/src/main/java/com/newslit/backend/audio/AudioPersistenceService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioPersistenceService.java
@@ -1,0 +1,106 @@
+package com.newslit.backend.audio;
+
+import com.newslit.backend.article.Article;
+import com.newslit.backend.article.ArticleRepository;
+import com.newslit.backend.article.exception.ArticleNotFoundException;
+import com.newslit.backend.audio.dto.WordDto;
+import com.newslit.backend.sentence.Sentence;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AudioPersistenceService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional
+    public void persistResults(Long articleId, String audioUrl, List<WordDto> words) {
+
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(ArticleNotFoundException::new);
+
+        article.setAudioLink(audioUrl);
+        List<Sentence> sentences = article.getSentences().stream()
+                .sorted(Comparator.comparing(Sentence::getOrderIndex))
+                .collect(Collectors.toList());
+
+        matchAndSaveTimestamps(words, sentences);
+    }
+
+
+    private void matchAndSaveTimestamps(List<WordDto> words, List<Sentence> sentences) {
+        if (words.isEmpty()) {
+            return;
+        }
+        int wordsStart = 0;
+        for (Sentence sentence : sentences) {
+
+            int endIdx = getEndIdx(sentence, words, wordsStart);
+
+            if (endIdx < wordsStart || endIdx >= words.size()) {
+                continue;
+            }
+
+            sentence.setStartTime(words.get(wordsStart).getStart());
+            sentence.setEndTime(words.get(endIdx).getEnd());
+
+            wordsStart = endIdx + 1;
+        }
+    }
+
+    private int getEndIdx(Sentence sentence, List<WordDto> words, int start) {
+        int startIdx = start;
+        List<String> sentenceWords = List.of(sentence.getEnglishText().split(" "));
+        for (String word : sentenceWords) {
+            for (int i = startIdx; i < words.size(); i++) {
+                String curWord = words.get(i).getWord();
+                if (isSimilar(word, curWord)) {
+                    startIdx = i + 1;
+                    break;
+                }
+            }
+        }
+        return startIdx - 1;
+    }
+
+    private boolean isSimilar(String word1, String word2) {
+        word1 = normalizeText(word1);
+        word2 = normalizeText(word2);
+
+        if (word1.equals(word2)) {
+            return true;
+        }
+
+        int distance = levenshteinDistance(word1, word2);
+        int maxLen = Math.max(word1.length(), word2.length());
+        return distance <= (maxLen * 0.1);
+
+    }
+
+    private int levenshteinDistance(String word1, String word2) {
+        int[][] dp = new int[word1.length() + 1][word2.length() + 1];
+
+        for (int i = 1; i <= word1.length(); i++) {
+            for (int j = 1; j <= word2.length(); j++) {
+                if (word1.charAt(i - 1) == word2.charAt(j - 1)) {
+                    dp[i][j] = dp[i - 1][j - 1];
+                } else {
+                    dp[i][j] = Math.min(Math.min(dp[i - 1][j], dp[i][j - 1]), dp[i - 1][j - 1]) + 1;
+                }
+            }
+        }
+        return dp[word1.length()][word2.length()];
+    }
+
+    private String normalizeText(String text) {
+        return text.replaceAll("[^\\w\\s]", "")
+                .replaceAll("\\s+", "")
+                .toLowerCase()
+                .trim();
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -6,10 +6,8 @@ import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.article.exception.ArticleNotFoundException;
 import com.newslit.backend.audio.dto.WhisperResponseDto;
 import com.newslit.backend.audio.dto.WordDto;
-import com.newslit.backend.sentence.Sentence;
 import com.oracle.bmc.objectstorage.ObjectStorage;
 import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
-import jakarta.transaction.Transactional;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,9 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.MediaType;
@@ -59,8 +55,8 @@ public class AudioService {
     private final ObjectMapper objectMapper;
     private final ObjectStorage objectStorage;
     private final ArticleRepository articleRepository;
+    private final AudioPersistenceService audioPersistenceService;
 
-    @Transactional
     public void saveTimeStamp(Long articleId) throws IOException {
 
         Article article = articleRepository.findById(articleId)
@@ -68,15 +64,13 @@ public class AudioService {
 
         File audioFile = downloadAudioFile(article.getAudioDownloadLink());
 
-        uploadMp3ToStorage(articleId, audioFile);
-
         try {
+            String audioUrl = uploadMp3ToStorage(articleId, audioFile);
             List<WordDto> words = transcribe(audioFile, article);
-            List<Sentence> sentences = article.getSentences().stream()
-                    .sorted(Comparator.comparing(Sentence::getOrderIndex))
-                    .collect(Collectors.toList());
 
-            matchAndSaveTimestamps(words, sentences);
+            audioPersistenceService.persistResults(articleId, audioUrl, words);
+
+
         } finally {
             audioFile.delete();
         }
@@ -104,76 +98,6 @@ public class AudioService {
         }
     }
 
-    private void matchAndSaveTimestamps(List<WordDto> words, List<Sentence> sentences) {
-        if (words.isEmpty()) {
-            return;
-        }
-        int wordsStart = 0;
-        for (Sentence sentence : sentences) {
-
-            int endIdx = getEndIdx(sentence, words, wordsStart);
-
-            if (endIdx < wordsStart || endIdx >= words.size()) {
-                continue;
-            }
-
-            sentence.setStartTime(words.get(wordsStart).getStart());
-            sentence.setEndTime(words.get(endIdx).getEnd());
-
-            wordsStart = endIdx + 1;
-        }
-    }
-
-    private int getEndIdx(Sentence sentence, List<WordDto> words, int start) {
-        int startIdx = start;
-        List<String> sentenceWords = List.of(sentence.getEnglishText().split(" "));
-        for (String word : sentenceWords) {
-            for (int i = startIdx; i < words.size(); i++) {
-                String curWord = words.get(i).getWord();
-                if (isSimilar(word, curWord)) {
-                    startIdx = i + 1;
-                    break;
-                }
-            }
-        }
-        return startIdx - 1;
-    }
-
-    private String normalizeText(String text) {
-        return text.replaceAll("[^\\w\\s]", "")
-                .replaceAll("\\s+", "")
-                .toLowerCase()
-                .trim();
-    }
-
-    private boolean isSimilar(String word1, String word2) {
-        word1 = normalizeText(word1);
-        word2 = normalizeText(word2);
-
-        if (word1.equals(word2)) {
-            return true;
-        }
-
-        int distance = levenshteinDistance(word1, word2);
-        int maxLen = Math.max(word1.length(), word2.length());
-        return distance <= (maxLen * 0.1);
-
-    }
-
-    private int levenshteinDistance(String word1, String word2) {
-        int[][] dp = new int[word1.length() + 1][word2.length() + 1];
-
-        for (int i = 1; i <= word1.length(); i++) {
-            for (int j = 1; j <= word2.length(); j++) {
-                if (word1.charAt(i - 1) == word2.charAt(j - 1)) {
-                    dp[i][j] = dp[i - 1][j - 1];
-                } else {
-                    dp[i][j] = Math.min(Math.min(dp[i - 1][j], dp[i][j - 1]), dp[i - 1][j - 1]) + 1;
-                }
-            }
-        }
-        return dp[word1.length()][word2.length()];
-    }
 
     private List<WordDto> transcribe(File audioFile, Article article) throws IOException {
         RequestBody requestBody = new MultipartBody.Builder()
@@ -207,7 +131,7 @@ public class AudioService {
     }
 
 
-    private void uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
+    private String uploadMp3ToStorage(Long articleId, File audioFile) throws IOException {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(ArticleNotFoundException::new);
 
@@ -242,8 +166,7 @@ public class AudioService {
                     encodedObjectName
             );
 
-            article.setAudioLink(audioUrl);
-            articleRepository.save(article);
+            return audioUrl;
         }
     }
 }

--- a/backend/src/main/java/com/newslit/backend/audio/AudioService.java
+++ b/backend/src/main/java/com/newslit/backend/audio/AudioService.java
@@ -65,7 +65,7 @@ public class AudioService {
         File audioFile = downloadAudioFile(article.getAudioDownloadLink());
 
         try {
-            String audioUrl = uploadMp3ToStorage(articleId, audioFile);
+            String audioUrl = uploadMp3ToStorage(article, audioFile);
             List<WordDto> words = transcribe(audioFile, article);
 
             audioPersistenceService.persistResults(articleId, audioUrl, words);

--- a/backend/src/main/java/com/newslit/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/newslit/backend/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.newslit.backend.global.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "externalApiExecutor")
+    public Executor externalApiExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("external-api-");
+        executor.setRejectedExecutionHandler(new CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
+++ b/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
@@ -50,7 +50,7 @@ public class DataSetupRunner implements CommandLineRunner {
 
         articleIds.stream().limit(2).forEach(i -> {
             try {
-                sentenceService.translateOneParagraph(i);
+                sentenceService.triggerTranslation(i);
                 articleRepository.findById(i)
                         .filter(article -> article.getAudioLink() == null || article.getAudioLink().isEmpty())
                         .ifPresent(article -> {

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceController.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceController.java
@@ -1,12 +1,12 @@
 package com.newslit.backend.sentence;
 
-import com.deepl.api.DeepLException;
 import com.newslit.backend.sentence.dto.SentenceResponseDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,11 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class SentenceController {
     private final SentenceService sentenceService;
 
-    @GetMapping
-    ResponseEntity<List<SentenceResponseDto>> translateOneParagraph(@RequestParam(name = "articleId") Long articleId) {
-        List<SentenceResponseDto> responses = sentenceService.translateOneParagraph(articleId);
+    @PostMapping("/translate")
+    ResponseEntity<Void> triggerTranslation(@RequestParam(name = "articleId") Long articleId) {
+        sentenceService.triggerTranslation(articleId);
+        return ResponseEntity.accepted().build();
+    }
 
-        return ResponseEntity.ok(responses);
+    @GetMapping
+    ResponseEntity<List<SentenceResponseDto>> getSentences(@RequestParam(name = "articleId") Long articleId) {
+        return ResponseEntity.ok(sentenceService.getSentences(articleId));
     }
 
 }

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -15,11 +15,6 @@ import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,8 +25,6 @@ public class SentenceService {
     private final SentenceRepository sentenceRepository;
     private final ArticleRepository articleRepository;
     private final TranslationAsyncService translationAsyncService;
-    //TODO: 삭제 요망
-    private final OkHttpClient client;
 
 
     public void triggerTranslation(Long articleId) {
@@ -79,18 +72,10 @@ public class SentenceService {
     public void retryTranslation(Sentence sentence) throws DeepLException, InterruptedException, IOException {
         sentence.incrementRetryCount();
         try {
-            //TODO: 테스트 위해 잠시 주석처리
-//            String translatedText = deepLClient
-//                    .translateText(sentence.getEnglishText(), null, "ko")
-//                    .getText();
-            Request request = new Request.Builder()
-                    .url("http://localhost:8090/api/translate")
-                    .post(RequestBody.create("{\"text\":\"" + sentence.getEnglishText() + "\"}",
-                            MediaType.parse("application/json")))
-                    .build();
+            String translatedText = deepLClient
+                    .translateText(sentence.getEnglishText(), null, "ko")
+                    .getText();
 
-            Response response = client.newCall(request).execute();
-            String translatedText = response.body().string();
             sentence.setKoreanText(translatedText);
             sentence.setTranslationStatus(Status.SUCCESS);
 

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -7,8 +7,7 @@ import com.newslit.backend.article.ArticleRepository;
 import com.newslit.backend.article.exception.ArticleNotFoundException;
 import com.newslit.backend.global.common.enums.Status;
 import com.newslit.backend.sentence.dto.SentenceResponseDto;
-import com.newslit.backend.sentence.exception.TranslationFailedException;
-import com.newslit.backend.sentence.exception.TranslationInterruptedException;
+import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +15,11 @@ import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -25,40 +29,39 @@ public class SentenceService {
     private final DeepLClient deepLClient;
     private final SentenceRepository sentenceRepository;
     private final ArticleRepository articleRepository;
+    private final TranslationAsyncService translationAsyncService;
+    //TODO: 삭제 요망
+    private final OkHttpClient client;
 
-    private static final int MAX_RETRY_CNT = 3;
 
-    public List<SentenceResponseDto> translateOneParagraph(Long articleId) {
+    public void triggerTranslation(Long articleId) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(ArticleNotFoundException::new);
 
         String paragraph = article.getOriginalText();
-        List<String> sentences = splitIntoSentencesAdvanced(paragraph);
-        List<SentenceResponseDto> responses = new ArrayList<>();
+        List<String> sentenceTexts = splitIntoSentencesAdvanced(paragraph);
 
-        for (int i = 0; i < sentences.size(); i++) {
-            SentenceResponseDto response = translateSingleSentence(articleId, article, sentences.get(i), i + 1);
-            responses.add(response);
+        for (int i = 0; i < sentenceTexts.size(); i++) {
+            String englishText = sentenceTexts.get(i);
+            int orderIndex = i + 1;
+
+            Optional<Sentence> existing = sentenceRepository.findByArticleIdAndEnglishText(articleId, englishText);
+
+            if (existing.isPresent() && existing.get().getTranslationStatus() == Status.SUCCESS) {
+                continue;
+            } else if (existing.isPresent() && existing.get().getTranslationStatus() == Status.PROCESSING) {
+                log.info("번역 진행 중인 문장 스킵 - orderIndex: {}", orderIndex);
+            } else {
+                Sentence sentence = existing.orElseGet(() -> createNewSentence(article, englishText, orderIndex));
+                translationAsyncService.translateAsync(sentence, englishText, articleId, orderIndex);
+            }
         }
-
-        return responses;
     }
 
-    public SentenceResponseDto translateSingleSentence(Long articleId, Article article, String englishText,
-                                                       int orderIndex) {
-
-        Optional<Sentence> existing = sentenceRepository
-                .findByArticleIdAndEnglishText(articleId, englishText);
-
-        //이미 번역 성공하여 저장되어있으면 pass
-        if (existing.isPresent() && existing.get().getTranslationStatus() == Status.SUCCESS) {
-            return toSentenceDto(existing.get());
-        }
-
-        //실패 상태거나, 없는 문장이면 해석 API 호출
-        Sentence sentence = existing.orElseGet(() -> createNewSentence(article, englishText, orderIndex));
-
-        return processTranslation(sentence, englishText, articleId, orderIndex);
+    public List<SentenceResponseDto> getSentences(Long articleId) {
+        return sentenceRepository.findAllByArticleId(articleId).stream()
+                .map(this::toSentenceDto)
+                .toList();
     }
 
     private Sentence createNewSentence(Article article, String englishText, int orderIndex) {
@@ -73,13 +76,21 @@ public class SentenceService {
         );
     }
 
-    public void retryTranslation(Sentence sentence) throws DeepLException, InterruptedException {
+    public void retryTranslation(Sentence sentence) throws DeepLException, InterruptedException, IOException {
         sentence.incrementRetryCount();
         try {
-            String translatedText = deepLClient
-                    .translateText(sentence.getEnglishText(), null, "ko")
-                    .getText();
+            //TODO: 테스트 위해 잠시 주석처리
+//            String translatedText = deepLClient
+//                    .translateText(sentence.getEnglishText(), null, "ko")
+//                    .getText();
+            Request request = new Request.Builder()
+                    .url("http://localhost:8090/api/translate")
+                    .post(RequestBody.create("{\"text\":\"" + sentence.getEnglishText() + "\"}",
+                            MediaType.parse("application/json")))
+                    .build();
 
+            Response response = client.newCall(request).execute();
+            String translatedText = response.body().string();
             sentence.setKoreanText(translatedText);
             sentence.setTranslationStatus(Status.SUCCESS);
 
@@ -90,43 +101,6 @@ public class SentenceService {
         } finally {
             sentenceRepository.save(sentence);
         }
-    }
-
-    private SentenceResponseDto processTranslation(Sentence sentence, String englishText,
-                                                   Long articleId, int orderIndex) {
-        sentence.setTranslationStatus(Status.PROCESSING);
-        sentenceRepository.save(sentence);
-
-        for (int retryCnt = 0; retryCnt < MAX_RETRY_CNT; retryCnt++) {
-            try {
-                if (retryCnt > 0) {
-                    Thread.sleep(500);
-                }
-                String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
-
-                sentence.setKoreanText(translatedText);
-                sentence.setTranslationStatus(Status.SUCCESS);
-                sentenceRepository.save(sentence);
-
-                return SentenceResponseDto.builder()
-                        .articleId(articleId)
-                        .orderIndex(orderIndex)
-                        .englishText(englishText)
-                        .koreanText(translatedText)
-                        .status(Status.SUCCESS)
-                        .build();
-            } catch (Exception e) {
-                if (e instanceof InterruptedException) {
-                    Thread.currentThread().interrupt();
-                    sentence.setTranslationStatus(Status.FAILED);
-                    sentenceRepository.save(sentence);
-                    throw new TranslationInterruptedException();
-                }
-            }
-        }
-        sentence.setTranslationStatus(Status.FAILED);
-        sentenceRepository.save(sentence);
-        throw new TranslationFailedException();
     }
 
     private List<String> splitIntoSentencesAdvanced(String text) {

--- a/backend/src/main/java/com/newslit/backend/sentence/TranslationAsyncService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/TranslationAsyncService.java
@@ -1,0 +1,51 @@
+package com.newslit.backend.sentence;
+
+import com.deepl.api.DeepLClient;
+import com.newslit.backend.global.common.enums.Status;
+import com.newslit.backend.sentence.dto.SentenceResponseDto;
+import com.newslit.backend.sentence.exception.TranslationFailedException;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TranslationAsyncService {
+    private final SentenceRepository sentenceRepository;
+    private final DeepLClient deepLClient;
+    private static final int MAX_RETRY_CNT = 3;
+
+    @Async("externalApiExecutor")
+    public void translateAsync(
+            Sentence sentence, String englishText, Long articleId, int orderIndex) {
+        sentence.setTranslationStatus(Status.PROCESSING);
+        sentenceRepository.save(sentence);
+
+        for (int retryCnt = 0; retryCnt < MAX_RETRY_CNT; retryCnt++) {
+            try {
+                String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
+
+                sentence.setKoreanText(translatedText);
+                sentence.setTranslationStatus(Status.SUCCESS);
+                sentenceRepository.save(sentence);
+
+                CompletableFuture.completedFuture(SentenceResponseDto.builder()
+                        .articleId(articleId)
+                        .orderIndex(orderIndex)
+                        .englishText(englishText)
+                        .koreanText(translatedText)
+                        .status(Status.SUCCESS)
+                        .build());
+                return;
+            } catch (Exception e) {
+                log.warn("번역 실패 (재시도 {}/{}): {}", retryCnt + 1, MAX_RETRY_CNT, e.getMessage());
+            }
+        }
+        sentence.setTranslationStatus(Status.FAILED);
+        sentenceRepository.save(sentence);
+        throw new TranslationFailedException();
+    }
+}

--- a/k6/deepl-fail.js
+++ b/k6/deepl-fail.js
@@ -1,0 +1,16 @@
+import http from "k6/http";
+import { check } from "k6";
+export const options = { vus: 250, duration: "30s" };
+
+export default function () {
+  if (Math.random() < 0.8) {
+    http.get("http://localhost:8080/api/sentence?articleId=513");
+  } else {
+    const healthyRes = http.get("http://localhost:8080/api/article/514");
+
+    check(healthyRes, {
+      "정상 API는 번역 장애에 휩쓸리지 않고 200 반환": (r) => r.status === 200,
+      "정상 API는 0.5초 이내 응답": (r) => r.timings.duration < 500,
+    });
+  }
+}


### PR DESCRIPTION
## 🔍 변경 사항
외부 API 호출 시 별도 쓰레드풀 사용
음성 API 관련 로직 트랜잭션 분리

## 🔗 연결 이슈: 
Closes #17

## 🛠️ 핵심 수정 사항 (How)
- AudioService에서 @Transactional 범위 내 외부 I/O(OCI 업로드, Whisper API) 수행하던 구조를 분리하여, DB 저장 로직만 AudioPersistenceService의 @Transactional 메서드로 이동
- 번역 API 호출을 @Async로 비동기 전환하여 TranslationAsyncService로 분리, 전용 쓰레드풀(core 5 / max 10 / queue 50, CallerRunsPolicy) 구성
- SentenceController의 번역 엔드포인트를 GET → POST /translate (202 Accepted)로 변경하고, 조회는 GET /sentences로 분리하여 Command/Query 책임 분리
- 번역 장애 시 정상 API 영향도 검증을 위한 k6 부하 테스트 스크립트 추가 — 250 VU, 30초 동안 80% 번역 / 20% 정상 API 혼합 호출
