### PR TITLE
fix: Oracle CLOB 타입 호환성 문제 수정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -43,6 +43,7 @@ tools/
 .env
 /src/main/resources/application-local-secret.properties
 /src/main/resources/application-prod-secret.properties
+/src/main/java/com/newslit/backend/global/config/CustomMySQLDialect.java
 
 ### Agent ###
 .claude

--- a/backend/src/main/java/com/newslit/backend/article/Article.java
+++ b/backend/src/main/java/com/newslit/backend/article/Article.java
@@ -47,7 +47,7 @@ public class Article {
     @Column(length = 500, nullable = false)
     private String title;
 
-    @JdbcTypeCode(SqlTypes.LONG32VARCHAR)
+    @JdbcTypeCode(SqlTypes.CLOB)
     @Column(nullable = false)
     private String originalText;
 

--- a/backend/src/main/java/com/newslit/backend/sentence/Sentence.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/Sentence.java
@@ -48,11 +48,11 @@ public class Sentence {
     @Column(name = "order_index", nullable = false)
     private Integer orderIndex;
 
-    @JdbcTypeCode(SqlTypes.LONG32VARCHAR)
+    @JdbcTypeCode(SqlTypes.CLOB)
     @Column(name = "english_text", nullable = false)
     private String englishText;
 
-    @JdbcTypeCode(SqlTypes.LONG32VARCHAR)
+    @JdbcTypeCode(SqlTypes.CLOB)
     @Column(name = "korean_text")
     private String koreanText;
 

--- a/backend/src/main/java/com/newslit/backend/vocabulary/Vocabulary.java
+++ b/backend/src/main/java/com/newslit/backend/vocabulary/Vocabulary.java
@@ -50,11 +50,11 @@ public class Vocabulary {
     @Column(name = "part_of_speech", length = 50)
     private PartOfSpeech partOfSpeech;
 
-    @JdbcTypeCode(SqlTypes.LONG32VARCHAR)
+    @JdbcTypeCode(SqlTypes.CLOB)
     @Column(name = "example_sentence")
     private String exampleSentence;
 
-    @JdbcTypeCode(SqlTypes.LONG32VARCHAR)
+    @JdbcTypeCode(SqlTypes.CLOB)
     @Column(name = "example_translation")
     private String exampleTranslation;
 


### PR DESCRIPTION
## 🔍 변경 사항
CLOB 적용 및 로컬 mysql을 위한 custom mysql dialect 생성

## 🔗 연결 이슈: 
Closes #25 

## 🛠️ 핵심 수정 사항 (How)
- Oracle은 JDBC 타입 4001(LONGVARCHAR)을 지원하지 않아 \`Invalid column type: 4001\` 오류 발생
- MySQL에서 \`@JdbcTypeCode(SqlTypes.CLOB)\` 사용 시 DDL이 \`tinytext\`(255byte)로 생성되는 문제는 로컬 전용 \`CustomMySQLDialect\`로 \`longtext\`로 오버라이드하여 해결
- \`CustomMySQLDialect.java\`는 로컬 전용 파일로 .gitignore에 추가됨

