### PR TITLE
refactor: 쿠키 생성 로직 메서드 분리

### DIFF
--- a/backend/src/main/java/com/newslit/backend/user/UserController.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserController.java
@@ -6,6 +6,7 @@ import com.newslit.backend.user.dto.LoginRequestDto;
 import com.newslit.backend.user.dto.SignupRequestDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -22,19 +23,16 @@ public class UserController {
     private final UserService userService;
     private final JwtUtil jwtUtil;
 
+    @Value("${app.cookie.secure}")
+    private boolean cookieSecure;
+
     @PostMapping("/signup")
     public ResponseEntity<AuthResponseDto> signup(@RequestBody SignupRequestDto request, HttpServletResponse response) {
         AuthResponseDto authResponseDto = userService.signup(request.getEmail(), request.getPassword(),
                 request.getNickname());
         String token = jwtUtil.generateToken(request.getEmail(), authResponseDto.getId(), authResponseDto.getRole());
 
-        ResponseCookie cookie = ResponseCookie.from("jwt", token)
-                .httpOnly(true)
-                .path("/")
-                .secure(false)
-                .maxAge(3600)
-                .sameSite("Lax")
-                .build();
+        ResponseCookie cookie = makeCookie(token, 3600);
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(authResponseDto);
@@ -45,13 +43,7 @@ public class UserController {
         AuthResponseDto authResponseDto = userService.login(request.getEmail(), request.getPassword());
         String token = jwtUtil.generateToken(request.getEmail(), authResponseDto.getId(), authResponseDto.getRole());
 
-        ResponseCookie cookie = ResponseCookie.from("jwt", token)
-                .httpOnly(true)
-                .secure(false)
-                .path("/")
-                .maxAge(3600)
-                .sameSite("Lax")
-                .build();
+        ResponseCookie cookie = makeCookie(token, 3600);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(authResponseDto);
     }
@@ -59,16 +51,20 @@ public class UserController {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletResponse response) {
 
-        ResponseCookie cookie = ResponseCookie.from("jwt", "")
-                .httpOnly(true)
-                .path("/")
-                .secure(false)
-                .maxAge(0)
-                .sameSite("Lax")
-                .build();
+        ResponseCookie cookie = makeCookie("", 0);
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return ResponseEntity.ok("Logout successful");
+    }
+
+    private ResponseCookie makeCookie(String token, int maxAge) {
+        return ResponseCookie.from("jwt", token)
+                .httpOnly(true)
+                .path("/")
+                .secure(cookieSecure)
+                .maxAge(maxAge)
+                .sameSite("Lax")
+                .build();
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/UserController.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserController.java
@@ -25,6 +25,8 @@ public class UserController {
 
     @Value("${app.cookie.secure}")
     private boolean cookieSecure;
+    @Value("${jwt.expiration}")
+    private long jwtExpiration;
 
     @PostMapping("/signup")
     public ResponseEntity<AuthResponseDto> signup(@RequestBody SignupRequestDto request, HttpServletResponse response) {
@@ -32,7 +34,7 @@ public class UserController {
                 request.getNickname());
         String token = jwtUtil.generateToken(request.getEmail(), authResponseDto.getId(), authResponseDto.getRole());
 
-        ResponseCookie cookie = makeCookie(token, 3600);
+        ResponseCookie cookie = makeCookie(token, jwtExpiration / 1000);
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(authResponseDto);
@@ -43,7 +45,7 @@ public class UserController {
         AuthResponseDto authResponseDto = userService.login(request.getEmail(), request.getPassword());
         String token = jwtUtil.generateToken(request.getEmail(), authResponseDto.getId(), authResponseDto.getRole());
 
-        ResponseCookie cookie = makeCookie(token, 3600);
+        ResponseCookie cookie = makeCookie(token, jwtExpiration / 1000);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(authResponseDto);
     }
@@ -58,7 +60,7 @@ public class UserController {
         return ResponseEntity.ok("Logout successful");
     }
 
-    private ResponseCookie makeCookie(String token, int maxAge) {
+    private ResponseCookie makeCookie(String token, long maxAge) {
         return ResponseCookie.from("jwt", token)
                 .httpOnly(true)
                 .path("/")

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,3 +16,4 @@ management.endpoint.health.show-details=always
 # Cache Configuration
 spring.cache.type=caffeine
 spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=24h
+jwt.expiration=3600000


### PR DESCRIPTION
## 🔍 변경 사항
쿠키 생성 로직 메서드 분리 및 PROD, LOCAL에 따른 Secure 적용
## 🔗 연결 이슈: 
Closes #22 

## 🛠️ 핵심 수정 사항 (How)
- secure(false) 하드코딩 제거 → 환경별 프로퍼티로 분리
- 쿠키 생성 로직 3곳 중복 → makeCookie() 하나로 통합
- boolean 타입으로 주입 → 잘못된 값이면 서버 시작 실패로 조기 감지

