### PR TITLE
Feature: 이메일 인증기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'com.oracle.database.security:osdt_core'
     implementation 'com.oracle.database.security:osdt_cert'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
     // Oracle Cloud SDK

--- a/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR-001", "사용자를 찾을 수 없습니다"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USR-002", "이미 존재하는 이메일입니다."),
+    ALREADY_VERIFIED(HttpStatus.CONFLICT, "USR-003", "이미 인증이 완료된 유저입니다."),
+    SEND_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "USR-004", "메일 발송 횟수를 초과했습니다."),
 
     // RSS
     RSS_NOT_FOUND(HttpStatus.NOT_FOUND, "RSS-002", "RSS 링크를 찾을 수 없습니다"),
@@ -31,6 +33,9 @@ public enum ErrorCode {
     TRANSLATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SNT-001", "번역 처리 중 오류가 발생했습니다"),
     TRANSLATION_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "SNT-002", "번역 작업이 중단되었습니다"),
     SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "SNT-003", "존재하지 않는 문장입니다");
+
+    //Email Verify
+
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/newslit/backend/global/common/enums/Verify.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/Verify.java
@@ -1,0 +1,6 @@
+package com.newslit.backend.global.common.enums;
+
+public enum Verify {
+    VERIFIED,
+    UNVERIFIED
+}

--- a/backend/src/main/java/com/newslit/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/newslit/backend/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/user/email/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
+++ b/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
@@ -7,6 +7,7 @@ import com.newslit.backend.crawl.VoaArticleCrawlerService;
 import com.newslit.backend.crawl.VoaRssCrawlerService;
 import com.newslit.backend.daily.DailyService;
 import com.newslit.backend.daily.exception.DuplicateDailyException;
+import com.newslit.backend.mail.MailService;
 import com.newslit.backend.rss.Rss;
 import com.newslit.backend.rss.RssRepository;
 import com.newslit.backend.sentence.SentenceService;
@@ -42,6 +43,7 @@ public class DataSetupRunner implements CommandLineRunner {
     private final AudioService audioService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
 
     @Value("${admin.email}")
     String email;
@@ -53,6 +55,8 @@ public class DataSetupRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
+
+        mailService.sendTestMail("hyeyeonkang424@gmail.com");
 
         if (userRepository.findByEmail(email).isEmpty()) {
             String encodedPassword = passwordEncoder.encode(password);

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
@@ -1,0 +1,72 @@
+package com.newslit.backend.mail;
+
+import com.newslit.backend.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "email_verification")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "code")
+    private String code;
+
+    @Column(name = "code_issued_at")
+    private LocalDateTime codeIssuedAt;
+
+    @Column(name = "attempt_count")
+    private Integer attemptCount;
+
+    @Column(name = "send_count")
+    private Integer sendCount;
+
+    @Column(name = "send_count_reset_dt")
+    private LocalDateTime sendCountResetDt;
+
+    public void increaseSendCount() {
+        this.sendCount++;
+    }
+
+    public void increaseAttemptCount() {
+        this.attemptCount++;
+    }
+
+    public void startNewSendCycle() {
+        this.sendCount = 1;
+        this.sendCountResetDt = LocalDateTime.now().plusDays(1);
+    }
+
+    public void resetAttemptCount() {
+        this.attemptCount = 0;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+        this.codeIssuedAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
@@ -38,11 +38,13 @@ public class EmailVerification {
     @Column(name = "code_issued_at")
     private LocalDateTime codeIssuedAt;
 
+    @Builder.Default
     @Column(name = "attempt_count")
-    private Integer attemptCount;
-
+    private Integer attemptCount = 0;
+    
+    @Builder.Default
     @Column(name = "send_count")
-    private Integer sendCount;
+    private Integer sendCount = 0;
 
     @Column(name = "send_count_reset_dt")
     private LocalDateTime sendCountResetDt;

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
@@ -56,7 +56,7 @@ public class EmailVerification {
     }
 
     public void startNewSendCycle() {
-        this.sendCount = 1;
+        this.sendCount = 0;
         this.sendCountResetDt = LocalDateTime.now().plusDays(1);
     }
 

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerificationRepository.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerificationRepository.java
@@ -1,0 +1,11 @@
+package com.newslit.backend.mail;
+
+import com.newslit.backend.user.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByUser(User user);
+}

--- a/backend/src/main/java/com/newslit/backend/mail/MailService.java
+++ b/backend/src/main/java/com/newslit/backend/mail/MailService.java
@@ -2,6 +2,7 @@ package com.newslit.backend.mail;
 
 import com.newslit.backend.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -11,9 +12,12 @@ import org.springframework.stereotype.Service;
 public class MailService {
     private final JavaMailSender mailSender;
 
+    @Value("${mail.verify-sender}")
+    private String sender;
+
     public void sendTestMail(String to) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom("noreply@newslit.net");
+        message.setFrom(sender);
         message.setTo(to);
         message.setSubject("Newslit 테스트 메일");
         message.setText("OCI Email Delivery로 발송된 메일입니다.");

--- a/backend/src/main/java/com/newslit/backend/mail/MailService.java
+++ b/backend/src/main/java/com/newslit/backend/mail/MailService.java
@@ -1,0 +1,21 @@
+package com.newslit.backend.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender mailSender;
+
+    public void sendTestMail(String to) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("noreply@newslit.net");  // Approved Sender에 등록한 주소
+        message.setTo(to);
+        message.setSubject("Newslit 테스트 메일");
+        message.setText("OCI Email Delivery로 발송된 메일입니다.");
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/mail/MailService.java
+++ b/backend/src/main/java/com/newslit/backend/mail/MailService.java
@@ -1,7 +1,6 @@
 package com.newslit.backend.mail;
 
 import com.newslit.backend.user.User;
-import com.newslit.backend.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -11,8 +10,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MailService {
     private final JavaMailSender mailSender;
-    private final EmailVerificationRepository emailVerificationRepository;
-    private final UserRepository userRepository;
 
     public void sendTestMail(String to) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/backend/src/main/java/com/newslit/backend/mail/MailService.java
+++ b/backend/src/main/java/com/newslit/backend/mail/MailService.java
@@ -2,7 +2,6 @@ package com.newslit.backend.mail;
 
 import com.newslit.backend.user.User;
 import com.newslit.backend.user.UserRepository;
-import com.newslit.backend.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -24,24 +23,13 @@ public class MailService {
         mailSender.send(message);
     }
 
-    public void sendVerifyMail(String to, String code) {
+    public void sendVerifyMail(User user, String code) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom("noreply@newslit.net");
-        message.setTo(to);
+        message.setTo(user.getEmail());
         message.setSubject("[Newslit] 인증 코드");
         message.setText(code);
 
-        User user = userRepository.findByEmail(to).orElseThrow(UserNotFoundException::new);
-
-        EmailVerification verification = emailVerificationRepository.findByUser(user)
-                .orElseGet(() -> EmailVerification.builder()
-                        .user(user)
-                        .sendCount(0)
-                        .attemptCount(0)
-                        .build());
-        verification.setCode(code);
         mailSender.send(message);
-        emailVerificationRepository.save(verification);
-
     }
 }

--- a/backend/src/main/java/com/newslit/backend/mail/MailService.java
+++ b/backend/src/main/java/com/newslit/backend/mail/MailService.java
@@ -1,5 +1,8 @@
 package com.newslit.backend.mail;
 
+import com.newslit.backend.user.User;
+import com.newslit.backend.user.UserRepository;
+import com.newslit.backend.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -9,13 +12,36 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MailService {
     private final JavaMailSender mailSender;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final UserRepository userRepository;
 
     public void sendTestMail(String to) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom("noreply@newslit.net");  // Approved Sender에 등록한 주소
+        message.setFrom("noreply@newslit.net");
         message.setTo(to);
         message.setSubject("Newslit 테스트 메일");
         message.setText("OCI Email Delivery로 발송된 메일입니다.");
         mailSender.send(message);
+    }
+
+    public void sendVerifyMail(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("noreply@newslit.net");
+        message.setTo(to);
+        message.setSubject("[Newslit] 인증 코드");
+        message.setText(code);
+
+        User user = userRepository.findByEmail(to).orElseThrow(UserNotFoundException::new);
+
+        EmailVerification verification = emailVerificationRepository.findByUser(user)
+                .orElseGet(() -> EmailVerification.builder()
+                        .user(user)
+                        .sendCount(0)
+                        .attemptCount(0)
+                        .build());
+        verification.setCode(code);
+        mailSender.send(message);
+        emailVerificationRepository.save(verification);
+
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/User.java
+++ b/backend/src/main/java/com/newslit/backend/user/User.java
@@ -1,5 +1,6 @@
 package com.newslit.backend.user;
 
+import com.newslit.backend.global.common.enums.Verify;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -42,6 +43,11 @@ public class User {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private Role role = Role.USER;
+
+    @Column(name = "verify_status", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'UNVERIFIED'")
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private Verify verify = Verify.UNVERIFIED;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/backend/src/main/java/com/newslit/backend/user/UserController.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserController.java
@@ -3,6 +3,8 @@ package com.newslit.backend.user;
 import com.newslit.backend.global.common.JwtUtil;
 import com.newslit.backend.user.dto.AuthResponseDto;
 import com.newslit.backend.user.dto.LoginRequestDto;
+import com.newslit.backend.user.dto.SendCodeRequestDto;
+import com.newslit.backend.user.dto.SendCodeResponseDto;
 import com.newslit.backend.user.dto.SignupRequestDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +60,13 @@ public class UserController {
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return ResponseEntity.ok("Logout successful");
+    }
+
+    @PostMapping("/email/send")
+    public ResponseEntity<SendCodeResponseDto> sendCode(@RequestBody SendCodeRequestDto request) {
+        SendCodeResponseDto dto = userService.sendCode(request.getEmail());
+
+        return ResponseEntity.ok(dto);
     }
 
     private ResponseCookie makeCookie(String token, long maxAge) {

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -1,8 +1,13 @@
 package com.newslit.backend.user;
 
+import com.newslit.backend.mail.EmailVerification;
+import com.newslit.backend.mail.EmailVerificationRepository;
+import com.newslit.backend.mail.MailService;
 import com.newslit.backend.user.dto.AuthResponseDto;
+import com.newslit.backend.user.dto.SendCodeResponseDto;
 import com.newslit.backend.user.exception.DuplicatedEmailException;
 import com.newslit.backend.user.exception.UserNotFoundException;
+import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,6 +18,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
+    private final EmailVerificationRepository emailVerificationRepository;
 
     public AuthResponseDto signup(String email, String password, String name) {
         userRepository.findByEmail(email).ifPresent(user -> {
@@ -54,6 +61,29 @@ public class UserService {
                 .role(user.getRole())
                 .nickname(user.getName())
                 .id(user.getId())
+                .build();
+    }
+
+    public SendCodeResponseDto sendCode(String email) {
+        String code = String.format("%06d", new SecureRandom().nextInt(1_000_000));
+
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+
+        EmailVerification verification = emailVerificationRepository.findByUser(user)
+                .orElseGet(() -> EmailVerification.builder()
+                        .user(user)
+                        .sendCount(0)
+                        .attemptCount(0)
+                        .build());
+        verification.setCode(code);
+
+        mailService.sendVerifyMail(user, code);
+        emailVerificationRepository.save(verification);
+
+        //TODO: 변경필요
+        return SendCodeResponseDto.builder()
+                .code("200")
+                .message("성공")
                 .build();
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -26,6 +26,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final MailService mailService;
     private final EmailVerificationRepository emailVerificationRepository;
+    private static final SecureRandom secureRandom = new SecureRandom();
 
     private static final Integer SEND_LIMIT = 20;
 
@@ -74,7 +75,7 @@ public class UserService {
 
     @Transactional
     public SendCodeResponseDto sendCode(String email) {
-        String code = String.format("%06d", new SecureRandom().nextInt(1_000_000));
+        String code = String.format("%06d", secureRandom.nextInt(1_000_000));
 
         Optional<User> optionalUser = userRepository.findByEmail(email);
         if (optionalUser.isEmpty()) {

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -1,16 +1,22 @@
 package com.newslit.backend.user;
 
+import com.newslit.backend.global.common.enums.Verify;
 import com.newslit.backend.mail.EmailVerification;
 import com.newslit.backend.mail.EmailVerificationRepository;
 import com.newslit.backend.mail.MailService;
 import com.newslit.backend.user.dto.AuthResponseDto;
 import com.newslit.backend.user.dto.SendCodeResponseDto;
+import com.newslit.backend.user.exception.AlreadyVerifiedException;
 import com.newslit.backend.user.exception.DuplicatedEmailException;
+import com.newslit.backend.user.exception.SendLimitExceededException;
 import com.newslit.backend.user.exception.UserNotFoundException;
 import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +26,8 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final MailService mailService;
     private final EmailVerificationRepository emailVerificationRepository;
+
+    private static final Integer SEND_LIMIT = 20;
 
     public AuthResponseDto signup(String email, String password, String name) {
         userRepository.findByEmail(email).ifPresent(user -> {
@@ -64,26 +72,46 @@ public class UserService {
                 .build();
     }
 
+    @Transactional
     public SendCodeResponseDto sendCode(String email) {
         String code = String.format("%06d", new SecureRandom().nextInt(1_000_000));
 
-        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        if (optionalUser.isEmpty()) {
+            return SendCodeResponseDto.builder()
+                    .message("인증코드 발송이 완료되었습니다.")
+                    .build();
+        }
+        User user = optionalUser.get();
+
+        if (user.getVerify() == Verify.VERIFIED) {
+            throw new AlreadyVerifiedException();
+        }
 
         EmailVerification verification = emailVerificationRepository.findByUser(user)
                 .orElseGet(() -> EmailVerification.builder()
                         .user(user)
                         .sendCount(0)
+                        .sendCountResetDt(LocalDateTime.now().plusDays(1))
                         .attemptCount(0)
                         .build());
+
+        if (verification.getSendCount() >= SEND_LIMIT) {
+            if (LocalDateTime.now().isAfter(verification.getSendCountResetDt())) {
+                verification.startNewSendCycle();
+            } else {
+                throw new SendLimitExceededException();
+            }
+        }
         verification.setCode(code);
+        verification.resetAttemptCount();
+        verification.increaseSendCount();
 
         mailService.sendVerifyMail(user, code);
         emailVerificationRepository.save(verification);
 
-        //TODO: 변경필요
         return SendCodeResponseDto.builder()
-                .code("200")
-                .message("성공")
+                .message("인증코드 발송이 완료되었습니다.")
                 .build();
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/dto/SendCodeRequestDto.java
+++ b/backend/src/main/java/com/newslit/backend/user/dto/SendCodeRequestDto.java
@@ -1,0 +1,14 @@
+package com.newslit.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SendCodeRequestDto {
+    private String email;
+}

--- a/backend/src/main/java/com/newslit/backend/user/dto/SendCodeResponseDto.java
+++ b/backend/src/main/java/com/newslit/backend/user/dto/SendCodeResponseDto.java
@@ -11,5 +11,4 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SendCodeResponseDto {
     String message;
-    String code;
 }

--- a/backend/src/main/java/com/newslit/backend/user/dto/SendCodeResponseDto.java
+++ b/backend/src/main/java/com/newslit/backend/user/dto/SendCodeResponseDto.java
@@ -1,0 +1,15 @@
+package com.newslit.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SendCodeResponseDto {
+    String message;
+    String code;
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/AlreadyVerifiedException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/AlreadyVerifiedException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class AlreadyVerifiedException extends BusinessException {
+    public AlreadyVerifiedException() {
+        super(ErrorCode.ALREADY_VERIFIED);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/SendLimitExceededException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/SendLimitExceededException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class SendLimitExceededException extends BusinessException {
+    public SendLimitExceededException() {
+        super(ErrorCode.SEND_LIMIT_EXCEEDED);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,3 +17,5 @@ management.endpoint.health.show-details=always
 spring.cache.type=caffeine
 spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=24h
 jwt.expiration=3600000
+# Mail Configuration
+mail.verify-sender=noreply@newslit.net


### PR DESCRIPTION
## 🔍 변경 사항
이메일 인증기능 구현
## 🔗 연결 이슈: 
Closes #28 

## 🛠️ 핵심 수정 사항 (How)

- **User 엔티티에 `verify_status` 컬럼 추가**: `Verify` enum(VERIFIED/UNVERIFIED)으로 이메일 인증 상태를 관리하며, 기본값은 UNVERIFIED
- **`email_verification` 테이블 신규 생성**: 인증 코드, 발급 시각, 시도 횟수, 발송 횟수, 발송 리셋 일시를 관리하는 엔티티 (User와 OneToOne 관계)
- **인증 코드 발송 API 추가** (`POST /api/user/email/send`): 6자리 SecureRandom 코드 생성 후 이메일 발송
- **이메일 열거 공격 방지**: 미가입 이메일 요청 시에도 동일한 성공 응답 반환 (실제 메일 미발송)
- **발송 제한 로직**: 일일 최대 20건 제한, `sendCountResetDt` 기준으로 자동 리셋
- **비즈니스 로직 분리**: `MailService`는 메일 발송만 담당, 검증/상태 관리 로직은 `UserService`에서 처리
- **에러 코드 추가**: `ALREADY_VERIFIED`(409), `SEND_LIMIT_EXCEEDED`(429) 등 이메일 인증 관련 예외 정의
