### PR TITLE
Feature/verify email

### DIFF
--- a/backend/src/main/java/com/newslit/backend/global/common/JwtTokenFilter.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtTokenFilter.java
@@ -1,6 +1,7 @@
 package com.newslit.backend.global.common;
 
 import com.newslit.backend.global.common.enums.TokenType;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -26,19 +27,25 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         String token = extractTokenFromCookie(request);
 
-        if (token == null || !jwtUtil.validateToken(token)) {
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Claims claims = jwtUtil.parseClaims(token);
+        if (claims == null) {
             response.setContentType("application/json;charset=UTF-8");
             filterChain.doFilter(request, response);
             return;
         }
 
-        if (TokenType.VERIFY.name().equals(jwtUtil.extractType(token))) {
+        if (TokenType.VERIFY.name().equals(claims.get("type", String.class))) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        Long userId = jwtUtil.extractId(token);
-        String role = jwtUtil.extractRole(token);
+        Long userId = claims.get("id", Long.class);
+        String role = claims.get("role", String.class);
         if (role == null) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtTokenFilter.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtTokenFilter.java
@@ -1,5 +1,6 @@
 package com.newslit.backend.global.common;
 
+import com.newslit.backend.global.common.enums.TokenType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -31,6 +32,11 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             return;
         }
 
+        if (jwtUtil.extractType(token).equals(TokenType.VERIFY.name())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         Long userId = jwtUtil.extractId(token);
         String role = jwtUtil.extractRole(token);
         if (role == null) {
@@ -52,11 +58,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if ("jwt".equals(cookie.getName())) {
+                if ("AUTH".equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }
         }
         return null;
     }
+
 }

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtTokenFilter.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtTokenFilter.java
@@ -32,7 +32,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (jwtUtil.extractType(token).equals(TokenType.VERIFY.name())) {
+        if (TokenType.VERIFY.name().equals(jwtUtil.extractType(token))) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
@@ -72,57 +72,16 @@ public class JwtUtil {
         }
     }
 
-    public String extractRole(String token) {
+
+    public Claims parseClaims(String token) {
         try {
             return Jwts.parser()
                     .verifyWith(signingKey)
                     .build()
                     .parseSignedClaims(token)
-                    .getPayload()
-                    .get("role", String.class);
+                    .getPayload();
         } catch (Exception e) {
-            log.error("EXTRACT ROLE ERROR", e);
             return null;
-        }
-    }
-
-    public String extractType(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(signingKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("type", String.class);
-        } catch (Exception e) {
-            log.error("EXTRACT TYPE ERROR", e);
-            return null;
-        }
-    }
-
-    public Long extractId(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(signingKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get("id", Long.class);
-        } catch (Exception e) {
-            log.error("EXTRACT ID ERROR", e);
-            return null;
-        }
-    }
-
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parser()
-                    .verifyWith(signingKey)
-                    .build()
-                    .parseSignedClaims(token);
-            return true;
-        } catch (Exception e) {
-            return false;
         }
     }
 }

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
@@ -86,6 +86,20 @@ public class JwtUtil {
         }
     }
 
+    public String extractType(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(signingKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("type", String.class);
+        } catch (Exception e) {
+            log.error("EXTRACT TYPE ERROR", e);
+            return null;
+        }
+    }
+
     public Long extractId(String token) {
         try {
             return Jwts.parser()

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
@@ -1,6 +1,9 @@
 package com.newslit.backend.global.common;
 
+import com.newslit.backend.global.common.enums.TokenType;
 import com.newslit.backend.user.Role;
+import com.newslit.backend.user.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
@@ -21,28 +24,44 @@ public class JwtUtil {
         this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(String email, Long id, Role role) {
+    public String generateAuthToken(String email, Long id, Role role) {
         return Jwts.builder()
                 .claim("email", email)
                 .claim("id", id)
                 .claim("role", role.name())
+                .claim("type", TokenType.AUTH.name())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .signWith(signingKey)
                 .compact();
     }
 
-    public String extractEmail(String token) {
+    public String generateVerifyToken(String email) {
+        return Jwts.builder()
+                .claim("email", email)
+                .claim("type", TokenType.VERIFY.name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    public String extractEmailFromVerifyToken(String token) {
         try {
-            return Jwts.parser()
-                    .verifyWith(signingKey)
-                    .build()
+            Claims claims = Jwts.parser()
+                    .verifyWith(signingKey).build()
                     .parseSignedClaims(token)
-                    .getPayload()
-                    .get("email", String.class);
+                    .getPayload();
+
+            if (!TokenType.VERIFY.name().equals(claims.get("type", String.class))) {
+                throw new InvalidTokenException();
+            }
+            return claims.get("email", String.class);
+        } catch (InvalidTokenException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("EXTRACT EMAIL ERROR", e);
-            return null;
+            log.error("EXTRACT EMAIL FROM VERIFY TOKEN ERROR", e);
+            throw new InvalidTokenException();
         }
     }
 

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
@@ -48,6 +48,9 @@ public class JwtUtil {
 
     public String extractEmailFromVerifyToken(String token) {
         try {
+            if (token == null) {
+                throw new InvalidTokenException();
+            }
             Claims claims = Jwts.parser()
                     .verifyWith(signingKey).build()
                     .parseSignedClaims(token)

--- a/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/JwtUtil.java
@@ -16,11 +16,15 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class JwtUtil {
-    private final long EXPIRATION_TIME;
+    private final long AUTH_EXPIRATION_TIME;
+    private final long VERIFY_EXPIRATION_TIME;
     private final SecretKey signingKey;
 
-    public JwtUtil(@Value("${jwt.expiration}") long expirationTime, @Value("${jwt.secret}") String secret) {
-        this.EXPIRATION_TIME = expirationTime;
+    public JwtUtil(@Value("${jwt.auth.expiration}") long authExpirationTime,
+                   @Value("${jwt.verify.expiration}") long verifyExpirationTime,
+                   @Value("${jwt.secret}") String secret) {
+        this.AUTH_EXPIRATION_TIME = authExpirationTime;
+        this.VERIFY_EXPIRATION_TIME = verifyExpirationTime;
         this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -31,7 +35,7 @@ public class JwtUtil {
                 .claim("role", role.name())
                 .claim("type", TokenType.AUTH.name())
                 .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .expiration(new Date(System.currentTimeMillis() + AUTH_EXPIRATION_TIME))
                 .signWith(signingKey)
                 .compact();
     }
@@ -41,7 +45,7 @@ public class JwtUtil {
                 .claim("email", email)
                 .claim("type", TokenType.VERIFY.name())
                 .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .expiration(new Date(System.currentTimeMillis() + VERIFY_EXPIRATION_TIME))
                 .signWith(signingKey)
                 .compact();
     }

--- a/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USR-002", "이미 존재하는 이메일입니다."),
     ALREADY_VERIFIED(HttpStatus.CONFLICT, "USR-003", "이미 인증이 완료된 유저입니다."),
     SEND_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "USR-004", "메일 발송 횟수를 초과했습니다."),
+    CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "USR-005", "해당 이메일로 등록된 코드를 찾을 수 없습니다."),
+    CODE_EXPIRED(HttpStatus.BAD_REQUEST, "USR-006", "만료된 코드입니다."),
+    WRONG_CODE(HttpStatus.BAD_REQUEST, "USR-007", "코드가 일치하지 않습니다."),
 
     // RSS
     RSS_NOT_FOUND(HttpStatus.NOT_FOUND, "RSS-002", "RSS 링크를 찾을 수 없습니다"),

--- a/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     WRONG_CODE(HttpStatus.BAD_REQUEST, "USR-007", "코드가 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USR-008", "유효하지 않은 토큰입니다."),
     EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, "USR-009", "인증된 이메일과 요청 이메일이 일치하지 않습니다."),
+    ATTEMPT_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "USR-010", "인증 시도 횟수를 초과했습니다."),
 
     // RSS
     RSS_NOT_FOUND(HttpStatus.NOT_FOUND, "RSS-002", "RSS 링크를 찾을 수 없습니다"),

--- a/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "USR-005", "해당 이메일로 등록된 코드를 찾을 수 없습니다."),
     CODE_EXPIRED(HttpStatus.BAD_REQUEST, "USR-006", "만료된 코드입니다."),
     WRONG_CODE(HttpStatus.BAD_REQUEST, "USR-007", "코드가 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USR-008", "유효하지 않은 토큰입니다."),
+    EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, "USR-009", "인증된 이메일과 요청 이메일이 일치하지 않습니다."),
 
     // RSS
     RSS_NOT_FOUND(HttpStatus.NOT_FOUND, "RSS-002", "RSS 링크를 찾을 수 없습니다"),

--- a/backend/src/main/java/com/newslit/backend/global/common/enums/TokenType.java
+++ b/backend/src/main/java/com/newslit/backend/global/common/enums/TokenType.java
@@ -1,0 +1,6 @@
+package com.newslit.backend.global.common.enums;
+
+public enum TokenType {
+    AUTH,
+    VERIFY
+}

--- a/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
+++ b/backend/src/main/java/com/newslit/backend/global/setup/DataSetupRunner.java
@@ -15,7 +15,6 @@ import com.newslit.backend.user.Role;
 import com.newslit.backend.user.User;
 import com.newslit.backend.user.UserRepository;
 import com.newslit.backend.vocabulary.VocabularyService;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -28,7 +27,7 @@ import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-@Profile({"local"})
+@Profile({"local-secret"})
 public class DataSetupRunner implements CommandLineRunner {
     private static final Logger log = LoggerFactory.getLogger(DataSetupRunner.class);
 
@@ -82,16 +81,6 @@ public class DataSetupRunner implements CommandLineRunner {
         articleIds.stream().limit(2).forEach(i -> {
             try {
                 sentenceService.triggerTranslation(i);
-                articleRepository.findById(i)
-                        .filter(article -> article.getAudioLink() == null || article.getAudioLink().isEmpty())
-                        .ifPresent(article -> {
-                            try {
-                                log.info("article {} 타임스탬프 시작", i);
-                                audioService.saveTimeStamp(i);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
                 log.info("Article {} 번역 완료", i);
             } catch (Exception e) {
                 log.error("Article {} 처리 중 오류 발생", i, e);

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
@@ -28,9 +28,8 @@ public class EmailVerification {
     @Column(name = "id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @Column(name = "email")
+    private String email;
 
     @Column(name = "code")
     private String code;
@@ -41,7 +40,7 @@ public class EmailVerification {
     @Builder.Default
     @Column(name = "attempt_count")
     private Integer attemptCount = 0;
-    
+
     @Builder.Default
     @Column(name = "send_count")
     private Integer sendCount = 0;

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerification.java
@@ -23,6 +23,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EmailVerification {
+    private static final long EXPIRATION_MINUTES = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -68,6 +70,10 @@ public class EmailVerification {
     public void setCode(String code) {
         this.code = code;
         this.codeIssuedAt = LocalDateTime.now();
+    }
+
+    public boolean isCodeExpired() {
+        return codeIssuedAt.plusMinutes(EXPIRATION_MINUTES).isBefore(LocalDateTime.now());
     }
 
 }

--- a/backend/src/main/java/com/newslit/backend/mail/EmailVerificationRepository.java
+++ b/backend/src/main/java/com/newslit/backend/mail/EmailVerificationRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
-    Optional<EmailVerification> findByUser(User user);
+    Optional<EmailVerification> findByEmail(String email);
 }

--- a/backend/src/main/java/com/newslit/backend/mail/MailService.java
+++ b/backend/src/main/java/com/newslit/backend/mail/MailService.java
@@ -24,10 +24,10 @@ public class MailService {
         mailSender.send(message);
     }
 
-    public void sendVerifyMail(User user, String code) {
+    public void sendVerifyMail(String email, String code) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom("noreply@newslit.net");
-        message.setTo(user.getEmail());
+        message.setTo(email);
         message.setSubject("[Newslit] 인증 코드");
         message.setText(code);
 

--- a/backend/src/main/java/com/newslit/backend/user/User.java
+++ b/backend/src/main/java/com/newslit/backend/user/User.java
@@ -1,6 +1,5 @@
 package com.newslit.backend.user;
 
-import com.newslit.backend.global.common.enums.Verify;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -43,11 +42,6 @@ public class User {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private Role role = Role.USER;
-
-    @Column(name = "verify_status", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'UNVERIFIED'")
-    @Builder.Default
-    @Enumerated(EnumType.STRING)
-    private Verify verify = Verify.UNVERIFIED;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/backend/src/main/java/com/newslit/backend/user/UserController.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserController.java
@@ -1,6 +1,7 @@
 package com.newslit.backend.user;
 
 import com.newslit.backend.global.common.JwtUtil;
+import com.newslit.backend.global.common.enums.TokenType;
 import com.newslit.backend.user.dto.AuthResponseDto;
 import com.newslit.backend.user.dto.LoginRequestDto;
 import com.newslit.backend.user.dto.SendCodeRequestDto;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,16 +30,20 @@ public class UserController {
 
     @Value("${app.cookie.secure}")
     private boolean cookieSecure;
-    @Value("${jwt.expiration}")
-    private long jwtExpiration;
+    @Value("${jwt.auth.expiration}")
+    private long authExpiration;
+    @Value("${jwt.verify.expiration}")
+    private long verifyExpiration;
 
     @PostMapping("/signup")
-    public ResponseEntity<AuthResponseDto> signup(@RequestBody SignupRequestDto request, HttpServletResponse response) {
+    public ResponseEntity<AuthResponseDto> signup(@RequestBody SignupRequestDto request, HttpServletResponse response,
+                                                  @CookieValue(name = "VERIFY", required = false) String verifyToken) {
         AuthResponseDto authResponseDto = userService.signup(request.getEmail(), request.getPassword(),
-                request.getNickname());
-        String token = jwtUtil.generateToken(request.getEmail(), authResponseDto.getId(), authResponseDto.getRole());
+                request.getNickname(), verifyToken);
+        String token = jwtUtil.generateAuthToken(request.getEmail(), authResponseDto.getId(),
+                authResponseDto.getRole());
 
-        ResponseCookie cookie = makeCookie(token, jwtExpiration / 1000);
+        ResponseCookie cookie = makeCookie(token, authExpiration / 1000, TokenType.AUTH);
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(authResponseDto);
@@ -46,9 +52,10 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDto> login(@RequestBody LoginRequestDto request, HttpServletResponse response) {
         AuthResponseDto authResponseDto = userService.login(request.getEmail(), request.getPassword());
-        String token = jwtUtil.generateToken(request.getEmail(), authResponseDto.getId(), authResponseDto.getRole());
+        String token = jwtUtil.generateAuthToken(request.getEmail(), authResponseDto.getId(),
+                authResponseDto.getRole());
 
-        ResponseCookie cookie = makeCookie(token, jwtExpiration / 1000);
+        ResponseCookie cookie = makeCookie(token, authExpiration / 1000, TokenType.AUTH);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(authResponseDto);
     }
@@ -56,7 +63,7 @@ public class UserController {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletResponse response) {
 
-        ResponseCookie cookie = makeCookie("", 0);
+        ResponseCookie cookie = makeCookie("", 0, TokenType.AUTH);
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
@@ -71,14 +78,17 @@ public class UserController {
     }
 
     @PostMapping("/email/verify")
-    public ResponseEntity<?> verifyCode(@RequestBody VerifyCodeRequestDto request) {
+    public ResponseEntity<?> verifyCode(@RequestBody VerifyCodeRequestDto request, HttpServletResponse response) {
         userService.verifyCode(request.getEmail(), request.getCode());
+        String verifyToken = jwtUtil.generateVerifyToken(request.getEmail());
+        ResponseCookie cookie = makeCookie(verifyToken, verifyExpiration / 1000, TokenType.VERIFY);
 
-        return ResponseEntity.ok().build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return ResponseEntity.ok("Verify successful");
     }
 
-    private ResponseCookie makeCookie(String token, long maxAge) {
-        return ResponseCookie.from("jwt", token)
+    private ResponseCookie makeCookie(String token, long maxAge, TokenType tokenType) {
+        return ResponseCookie.from(tokenType.name(), token)
                 .httpOnly(true)
                 .path("/")
                 .secure(cookieSecure)

--- a/backend/src/main/java/com/newslit/backend/user/UserController.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserController.java
@@ -6,6 +6,7 @@ import com.newslit.backend.user.dto.LoginRequestDto;
 import com.newslit.backend.user.dto.SendCodeRequestDto;
 import com.newslit.backend.user.dto.SendCodeResponseDto;
 import com.newslit.backend.user.dto.SignupRequestDto;
+import com.newslit.backend.user.dto.VerifyCodeRequestDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -67,6 +68,13 @@ public class UserController {
         SendCodeResponseDto dto = userService.sendCode(request.getEmail());
 
         return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<?> verifyCode(@RequestBody VerifyCodeRequestDto request) {
+        userService.verifyCode(request.getEmail(), request.getCode());
+
+        return ResponseEntity.ok().build();
     }
 
     private ResponseCookie makeCookie(String token, long maxAge) {

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -7,9 +7,12 @@ import com.newslit.backend.mail.MailService;
 import com.newslit.backend.user.dto.AuthResponseDto;
 import com.newslit.backend.user.dto.SendCodeResponseDto;
 import com.newslit.backend.user.exception.AlreadyVerifiedException;
+import com.newslit.backend.user.exception.CodeExpiredException;
+import com.newslit.backend.user.exception.CodeNotFoundException;
 import com.newslit.backend.user.exception.DuplicatedEmailException;
 import com.newslit.backend.user.exception.SendLimitExceededException;
 import com.newslit.backend.user.exception.UserNotFoundException;
+import com.newslit.backend.user.exception.WrongCodeException;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -105,5 +108,24 @@ public class UserService {
         return SendCodeResponseDto.builder()
                 .message("인증코드 발송이 완료되었습니다.")
                 .build();
+    }
+
+    public void verifyCode(String email, String code) {
+
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new WrongCodeException();
+        }
+
+        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email).orElseThrow(
+                CodeNotFoundException::new);
+
+        if (emailVerification.isCodeExpired()) {
+            throw new CodeExpiredException();
+        }
+
+        if (!emailVerification.getCode().equals(code)) {
+            throw new WrongCodeException();
+        }
+
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -75,23 +75,14 @@ public class UserService {
 
     @Transactional
     public SendCodeResponseDto sendCode(String email) {
-        String code = String.format("%06d", secureRandom.nextInt(1_000_000));
-
-        Optional<User> optionalUser = userRepository.findByEmail(email);
-        if (optionalUser.isEmpty()) {
-            return SendCodeResponseDto.builder()
-                    .message("인증코드 발송이 완료되었습니다.")
-                    .build();
-        }
-        User user = optionalUser.get();
-
-        if (user.getVerify() == Verify.VERIFIED) {
+        if (userRepository.findByEmail(email).isPresent()) {
             throw new AlreadyVerifiedException();
         }
 
-        EmailVerification verification = emailVerificationRepository.findByUser(user)
+        String code = String.format("%06d", secureRandom.nextInt(1_000_000));
+        EmailVerification verification = emailVerificationRepository.findByEmail(email)
                 .orElseGet(() -> EmailVerification.builder()
-                        .user(user)
+                        .email(email)
                         .sendCount(0)
                         .sendCountResetDt(LocalDateTime.now().plusDays(1))
                         .attemptCount(0)
@@ -108,7 +99,7 @@ public class UserService {
         verification.resetAttemptCount();
         verification.increaseSendCount();
 
-        mailService.sendVerifyMail(user, code);
+        mailService.sendVerifyMail(email, code);
         emailVerificationRepository.save(verification);
 
         return SendCodeResponseDto.builder()

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -88,7 +88,9 @@ public class UserService {
     @Transactional
     public SendCodeResponseDto sendCode(String email) {
         if (userRepository.findByEmail(email).isPresent()) {
-            throw new AlreadyVerifiedException();
+            return SendCodeResponseDto.builder()
+                    .message("인증코드 발송이 완료되었습니다.")
+                    .build();
         }
 
         String code = String.format("%06d", secureRandom.nextInt(1_000_000));

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -124,7 +124,7 @@ public class UserService {
     public void verifyCode(String email, String code) {
 
         if (userRepository.findByEmail(email).isPresent()) {
-            throw new WrongCodeException();
+            return;
         }
 
         EmailVerification emailVerification = emailVerificationRepository.findByEmail(email).orElseThrow(

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -1,13 +1,12 @@
 package com.newslit.backend.user;
 
 import com.newslit.backend.global.common.JwtUtil;
-import com.newslit.backend.global.common.enums.Verify;
 import com.newslit.backend.mail.EmailVerification;
 import com.newslit.backend.mail.EmailVerificationRepository;
 import com.newslit.backend.mail.MailService;
 import com.newslit.backend.user.dto.AuthResponseDto;
 import com.newslit.backend.user.dto.SendCodeResponseDto;
-import com.newslit.backend.user.exception.AlreadyVerifiedException;
+import com.newslit.backend.user.exception.AttemptLimitExceededException;
 import com.newslit.backend.user.exception.CodeExpiredException;
 import com.newslit.backend.user.exception.CodeNotFoundException;
 import com.newslit.backend.user.exception.DuplicatedEmailException;
@@ -17,7 +16,6 @@ import com.newslit.backend.user.exception.UserNotFoundException;
 import com.newslit.backend.user.exception.WrongCodeException;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -34,6 +32,7 @@ public class UserService {
     private static final SecureRandom secureRandom = new SecureRandom();
 
     private static final Integer SEND_LIMIT = 20;
+    private static final Integer MAX_ATTEMPT = 5;
     private final JwtUtil jwtUtil;
 
     public AuthResponseDto signup(String email, String password, String name, String verifyToken) {
@@ -121,6 +120,7 @@ public class UserService {
                 .build();
     }
 
+    @Transactional
     public void verifyCode(String email, String code) {
 
         if (userRepository.findByEmail(email).isPresent()) {
@@ -134,9 +134,16 @@ public class UserService {
             throw new CodeExpiredException();
         }
 
+        if (emailVerification.getAttemptCount() >= MAX_ATTEMPT) {
+            throw new AttemptLimitExceededException();
+        }
+
         if (!emailVerification.getCode().equals(code)) {
+            emailVerification.increaseAttemptCount();
             throw new WrongCodeException();
         }
+
+        emailVerification.resetAttemptCount();
 
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/UserService.java
+++ b/backend/src/main/java/com/newslit/backend/user/UserService.java
@@ -1,5 +1,6 @@
 package com.newslit.backend.user;
 
+import com.newslit.backend.global.common.JwtUtil;
 import com.newslit.backend.global.common.enums.Verify;
 import com.newslit.backend.mail.EmailVerification;
 import com.newslit.backend.mail.EmailVerificationRepository;
@@ -10,6 +11,7 @@ import com.newslit.backend.user.exception.AlreadyVerifiedException;
 import com.newslit.backend.user.exception.CodeExpiredException;
 import com.newslit.backend.user.exception.CodeNotFoundException;
 import com.newslit.backend.user.exception.DuplicatedEmailException;
+import com.newslit.backend.user.exception.EmailMismatchException;
 import com.newslit.backend.user.exception.SendLimitExceededException;
 import com.newslit.backend.user.exception.UserNotFoundException;
 import com.newslit.backend.user.exception.WrongCodeException;
@@ -32,8 +34,15 @@ public class UserService {
     private static final SecureRandom secureRandom = new SecureRandom();
 
     private static final Integer SEND_LIMIT = 20;
+    private final JwtUtil jwtUtil;
 
-    public AuthResponseDto signup(String email, String password, String name) {
+    public AuthResponseDto signup(String email, String password, String name, String verifyToken) {
+        String tokenEmail = jwtUtil.extractEmailFromVerifyToken(verifyToken);
+
+        if (!tokenEmail.equals(email)) {
+            throw new EmailMismatchException();
+        }
+
         userRepository.findByEmail(email).ifPresent(user -> {
             throw new DuplicatedEmailException();
         });

--- a/backend/src/main/java/com/newslit/backend/user/dto/VerifyCodeRequestDto.java
+++ b/backend/src/main/java/com/newslit/backend/user/dto/VerifyCodeRequestDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class SendCodeRequestDto {
+public class VerifyCodeRequestDto {
     private String email;
+    private String code;
 }

--- a/backend/src/main/java/com/newslit/backend/user/dto/VerifyCodeRequestDto.java
+++ b/backend/src/main/java/com/newslit/backend/user/dto/VerifyCodeRequestDto.java
@@ -1,0 +1,14 @@
+package com.newslit.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SendCodeRequestDto {
+    private String email;
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/AttemptLimitExceededException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/AttemptLimitExceededException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class AttemptLimitExceededException extends BusinessException {
+    public AttemptLimitExceededException() {
+        super(ErrorCode.ATTEMPT_LIMIT_EXCEEDED);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/CodeExpiredException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/CodeExpiredException.java
@@ -3,8 +3,8 @@ package com.newslit.backend.user.exception;
 import com.newslit.backend.global.common.dto.BusinessException;
 import com.newslit.backend.global.common.enums.ErrorCode;
 
-public class CodeNotFoundException extends BusinessException {
-    public CodeNotFoundException() {
-        super(ErrorCode.ALREADY_VERIFIED);
+public class CodeExpiredException extends BusinessException {
+    public CodeExpiredException() {
+        super(ErrorCode.CODE_EXPIRED);
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/exception/CodeExpiredException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/CodeExpiredException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class CodeNotFoundException extends BusinessException {
+    public CodeNotFoundException() {
+        super(ErrorCode.ALREADY_VERIFIED);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/CodeNotFoundException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/CodeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class AlreadyVerifiedException extends BusinessException {
+    public AlreadyVerifiedException() {
+        super(ErrorCode.ALREADY_VERIFIED);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/CodeNotFoundException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/CodeNotFoundException.java
@@ -3,8 +3,8 @@ package com.newslit.backend.user.exception;
 import com.newslit.backend.global.common.dto.BusinessException;
 import com.newslit.backend.global.common.enums.ErrorCode;
 
-public class AlreadyVerifiedException extends BusinessException {
-    public AlreadyVerifiedException() {
-        super(ErrorCode.ALREADY_VERIFIED);
+public class CodeNotFoundException extends BusinessException {
+    public CodeNotFoundException() {
+        super(ErrorCode.CODE_NOT_FOUND);
     }
 }

--- a/backend/src/main/java/com/newslit/backend/user/exception/EmailMismatchException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/EmailMismatchException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class EmailMismatchException extends BusinessException {
+    public EmailMismatchException() {
+        super(ErrorCode.EMAIL_MISMATCH);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/InvalidTokenException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class InvalidTokenException extends BusinessException {
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/WrongCodeException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/WrongCodeException.java
@@ -1,0 +1,10 @@
+package com.newslit.backend.user.exception;
+
+import com.newslit.backend.global.common.dto.BusinessException;
+import com.newslit.backend.global.common.enums.ErrorCode;
+
+public class CodeNotFoundException extends BusinessException {
+    public CodeNotFoundException() {
+        super(ErrorCode.CODE_NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/newslit/backend/user/exception/WrongCodeException.java
+++ b/backend/src/main/java/com/newslit/backend/user/exception/WrongCodeException.java
@@ -3,8 +3,8 @@ package com.newslit.backend.user.exception;
 import com.newslit.backend.global.common.dto.BusinessException;
 import com.newslit.backend.global.common.enums.ErrorCode;
 
-public class CodeNotFoundException extends BusinessException {
-    public CodeNotFoundException() {
-        super(ErrorCode.CODE_NOT_FOUND);
+public class WrongCodeException extends BusinessException {
+    public WrongCodeException() {
+        super(ErrorCode.WRONG_CODE);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,7 +16,8 @@ management.endpoint.health.show-details=always
 # Cache Configuration
 spring.cache.type=caffeine
 spring.cache.caffeine.spec=maximumSize=500,expireAfterWrite=24h
-jwt.expiration=3600000
+jwt.auth.expiration=3600000
+jwt.verify.expiration=600000
 # Mail Configuration
 mail.verify-sender=noreply@newslit.net
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration,org.springframework.boot.autoconfigure.mail.MailSenderValidatorAutoConfiguration


### PR DESCRIPTION
## 🔍 변경 사항

회원가입 시 이메일 인증을 완료한 사용자만 가입할 수 있도록 이메일 인증 로직 추가

## 🔗 연결 이슈
Closes #32

## 🛠️ 핵심 수정 사항 (How)

- **EmailVerification 엔티티 구조 변경**
  - `User`와의 연관관계(`@OneToOne`) 제거, `email` 컬럼으로 대체
  - 회원가입 전 단계에서도 인증 코드 저장 가능하도록 개선

- **이메일 인증 플로우 신규 구현**
  - `POST /api/user/email/send`: 미가입 이메일에도 코드 발송 가능하도록 수정 (이미 가입된 이메일은 보안상 성공 응답만 반환)
  - `POST /api/user/email/verify`: 코드 검증 후 `type: VERIFY`, `email` 클레임을 담은 단기(10분) JWT를 `VERIFY` 쿠키로 발급

- **회원가입 검증 강화**
  - `POST /api/user/signup`: 요청 시 `VERIFY` 쿠키의 JWT 유효성 및 이메일 일치 여부 검증 후 DB 저장

- **JWT 이중 토큰 구조 도입**
  - `generateAuthToken()`: 로그인/회원가입용 (`type: AUTH`, `id`, `email`, `role` 포함)
  - `generateVerifyToken()`: 이메일 인증용 (`type: VERIFY`, `email` 포함, 10분 만료)
  - `jwt.auth.expiration`, `jwt.verify.expiration`으로 만료 시간 분리 관리

- **JwtTokenFilter 개선**
  - `AUTH` 쿠키만 읽도록 수정
  - `type` 클레임 기반으로 분기 처리: `VERIFY` 토큰은 SecurityContext에 등록하지 않고 통과