### PR TITLE
Feature: Java 21 버전업 및 Audio Test 정리

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -16,11 +16,11 @@ jobs:
       - name: 체크아웃
         uses: actions/checkout@v4
 
-      - name: JDK 17 설정
+      - name: JDK 21 설정
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: "gradle"
 
       - name: 설정 파일 생성

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -10,7 +10,7 @@ description = 'backend'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,8 +8,8 @@ springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.display-request-duration=true
 springdoc.swagger-ui.operations-sorter=alpha
 spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
-#spring.profiles.active=local,local-secret
-spring.profiles.active=prod-secret
+spring.profiles.active=local,local-secret
+#spring.profiles.active=prod-secret
 # Actuator ??
 management.endpoints.web.exposure.include=health,info
 management.endpoints.web.base-path=/actuator

--- a/backend/src/test/java/com/newslit/backend/audio/AudioServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/audio/AudioServiceTest.java
@@ -103,8 +103,10 @@ class AudioServiceTest {
 
     @AfterEach
     void cleanup() {
-        sentenceRepository.deleteAll(sentenceRepository.findAllByArticleId(articleId));
-        articleRepository.deleteById(articleId);
+        if (articleId != null) {
+            sentenceRepository.deleteAll(sentenceRepository.findAllByArticleId(articleId));
+            articleRepository.deleteById(articleId);
+        }
     }
 
     @AfterAll

--- a/backend/src/test/java/com/newslit/backend/audio/AudioServiceTest.java
+++ b/backend/src/test/java/com/newslit/backend/audio/AudioServiceTest.java
@@ -1,29 +1,126 @@
 package com.newslit.backend.audio;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.transaction.Transactional;
+import com.newslit.backend.article.Article;
+import com.newslit.backend.article.ArticleRepository;
+import com.newslit.backend.sentence.Sentence;
+import com.newslit.backend.sentence.SentenceRepository;
+import com.oracle.bmc.objectstorage.ObjectStorage;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
+import java.time.LocalDate;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest
-@Slf4j
 class AudioServiceTest {
-    @Autowired
-    private AudioService audioService;
 
-    @Test
-    void audio_test() {
+    private static final MockWebServer mockWebServer = new MockWebServer();
+
+    static {
         try {
-            log.info("article {} 타임스탬프 시작", 50);
-            audioService.saveTimeStamp(50L);
+            mockWebServer.start();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
+    @DynamicPropertySource
+    static void overrideOpenAiUrl(DynamicPropertyRegistry registry) {
+        registry.add("openai.url", () -> mockWebServer.url("/v1/audio/transcriptions").toString());
+    }
 
+    @Autowired
+    private AudioService audioService;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private SentenceRepository sentenceRepository;
+
+    // Oracle Cloud Object Storage로 실제 업로드가 나가지 않도록 목으로 대체
+    @MockBean
+    private ObjectStorage objectStorage;
+
+    private Long articleId;
+
+    @BeforeEach
+    void setup() {
+        mockWebServer.setDispatcher(new Dispatcher() {
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest request) {
+                if (request.getPath() != null && request.getPath().startsWith("/audio")) {
+                    return new MockResponse()
+                            .setResponseCode(200)
+                            .setBody("fake-audio-bytes");
+                }
+                return new MockResponse()
+                        .setResponseCode(200)
+                        .addHeader("Content-Type", "application/json")
+                        .setBody("""
+                                {
+                                  "text": "Hello world.",
+                                  "language": "english",
+                                  "duration": 1.2,
+                                  "words": [
+                                    {"word": "Hello", "start": 0.0, "end": 0.4},
+                                    {"word": "world.", "start": 0.4, "end": 1.0}
+                                  ]
+                                }
+                                """);
+            }
+        });
+
+        Article article = articleRepository.save(Article.builder()
+                .title("Audio Test Article " + System.nanoTime())
+                .originalText("Hello world.")
+                .publishedDate(LocalDate.now())
+                .source("test")
+                .audioDownloadLink(mockWebServer.url("/audio.mp3").toString())
+                .build());
+        articleId = article.getId();
+
+        sentenceRepository.save(Sentence.builder()
+                .article(article)
+                .orderIndex(0)
+                .englishText("Hello world.")
+                .build());
+    }
+
+    @AfterEach
+    void cleanup() {
+        sentenceRepository.deleteAll(sentenceRepository.findAllByArticleId(articleId));
+        articleRepository.deleteById(articleId);
+    }
+
+    @AfterAll
+    static void shutdownServer() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void audio_test() throws IOException {
+        audioService.saveTimeStamp(articleId);
+
+        Article saved = articleRepository.findById(articleId).orElseThrow();
+        assertThat(saved.getAudioLink()).isNotBlank();
+
+        Sentence sentence = sentenceRepository.findAllByArticleId(articleId).get(0);
+        assertThat(sentence.getStartTime()).isNotNull();
+        assertThat(sentence.getEndTime()).isNotNull();
+    }
 }


### PR DESCRIPTION
## 🔍 변경 사항

- Java 17 → 21 버전업 (build.gradle, CI 워크플로, 배포 서버 systemd 설정)
- 로컬 테스트 실행 시 프로덕션 Oracle DB에 연결되던 기본 프로필 설정 수정
- `AudioServiceTest`를 하드코딩된 article id 의존성에서 픽스처 기반으로 재작성

## 🔗 연결 이슈: 
Closes #44 

## 🛠️ 핵심 수정 사항 (How)

- **Java 21 버전업**
  - `build.gradle`의 `languageVersion`을 17 → 21로 변경
  - GitHub Actions 배포 워크플로(`deploy-backend.yml`)의 `setup-java` 버전을 21로 변경
  - 배포 서버 systemd 유닛(`newslit@.service`)의 `ExecStart` java 경로를 Temurin 21로 교체 (인프라 설정, 레포 외부 변경)

- **테스트 프로필 안전성 수정**
  - `application.properties`의 기본 `spring.profiles.active`가 `prod-secret`으로 설정돼 있어, 로컬에서 프로필 지정 없이 `./gradlew test`를 실행하면 실제 프로덕션 Oracle DB에 연결되는 문제 발견
  - 기본값을 `local,local-secret`으로 변경해 로컬 실행/테스트는 항상 로컬 MySQL을 사용하도록 수정
  - 배포 파이프라인은 CI/systemd에서 `-Dspring.profiles.active=prod-secret`을 명시적으로 지정하고 있어 프로덕션 동작에는 영향 없음

- **AudioServiceTest 재작성**
  - 기존 테스트는 DB에 미리 존재해야 하는 특정 article id(`50L`)에 의존해 환경에 따라 항상 실패하는 문제가 있었음
  - `@BeforeEach`에서 Article/Sentence 픽스처를 직접 생성·저장하고 해당 id로 테스트하도록 변경
  - Oracle Cloud Object Storage 업로드는 `@MockBean`으로 대체
  - OpenAI Whisper API 호출 및 오디오 다운로드는 `MockWebServer` + `@DynamicPropertySource`로 목서버를 바라보게 해 실제 외부 API 호출/비용 없이 검증
  - 테스트 종료 후 생성한 픽스처만 정리하도록 처리