### PR TITLE
refactor: 번역 재시도를 Spring Retry 기반으로 전환

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.retry:spring-retry'
     implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/newslit/backend/global/config/RetryConfig.java
+++ b/backend/src/main/java/com/newslit/backend/global/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.newslit.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/SentenceService.java
@@ -46,7 +46,7 @@ public class SentenceService {
                 log.info("번역 진행 중인 문장 스킵 - orderIndex: {}", orderIndex);
             } else {
                 Sentence sentence = existing.orElseGet(() -> createNewSentence(article, englishText, orderIndex));
-                translationAsyncService.translateAsync(sentence, englishText, articleId, orderIndex);
+                translationAsyncService.translateAsync(sentence, englishText, articleId);
             }
         }
     }

--- a/backend/src/main/java/com/newslit/backend/sentence/TranslationAsyncService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/TranslationAsyncService.java
@@ -1,6 +1,5 @@
 package com.newslit.backend.sentence;
 
-import com.deepl.api.DeepLClient;
 import com.newslit.backend.global.common.enums.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,30 +10,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class TranslationAsyncService {
+
     private final SentenceRepository sentenceRepository;
-    private final DeepLClient deepLClient;
-    private static final int MAX_RETRY_CNT = 3;
+    private final TranslationRetryService translationRetryService;
 
     @Async("externalApiExecutor")
-    public void translateAsync(
-            Sentence sentence, String englishText, Long articleId, int orderIndex) {
+    public void translateAsync(Sentence sentence, String englishText, Long articleId) {
         sentence.setTranslationStatus(Status.PROCESSING);
         sentenceRepository.save(sentence);
 
-        for (int retryCnt = 0; retryCnt < MAX_RETRY_CNT; retryCnt++) {
-            try {
-                String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
-
-                sentence.setKoreanText(translatedText);
-                sentence.setTranslationStatus(Status.SUCCESS);
-                sentenceRepository.save(sentence);
-                return;
-            } catch (Exception e) {
-                log.warn("번역 실패 (재시도 {}/{}): {}", retryCnt + 1, MAX_RETRY_CNT, e.getMessage());
-            }
+        try {
+            translationRetryService.translate(sentence, englishText, articleId);
+        } catch (Exception e) {
+            log.error("번역 처리 중 복구되지 않은 예외 - sentenceId: {}, articleId: {}",
+                    sentence.getId(), articleId, e);
         }
-        sentence.setTranslationStatus(Status.FAILED);
-        sentenceRepository.save(sentence);
-        log.error("번역 최종 실패 - sentenceId: {}, articleId: {}", sentence.getId(), articleId);
     }
 }

--- a/backend/src/main/java/com/newslit/backend/sentence/TranslationRetryService.java
+++ b/backend/src/main/java/com/newslit/backend/sentence/TranslationRetryService.java
@@ -1,0 +1,42 @@
+package com.newslit.backend.sentence;
+
+import com.deepl.api.DeepLClient;
+import com.deepl.api.DeepLException;
+import com.newslit.backend.global.common.enums.Status;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TranslationRetryService {
+
+    static final int MAX_ATTEMPTS = 3;
+
+    private final SentenceRepository sentenceRepository;
+    private final DeepLClient deepLClient;
+
+    @Retryable(
+            maxAttempts = MAX_ATTEMPTS,
+            backoff = @Backoff(delay = 500, multiplier = 2, maxDelay = 2000, random = true))
+    public void translate(Sentence sentence, String englishText, Long articleId)
+            throws DeepLException, InterruptedException {
+        String translatedText = deepLClient.translateText(englishText, null, "ko").getText();
+
+        sentence.setKoreanText(translatedText);
+        sentence.setTranslationStatus(Status.SUCCESS);
+        sentenceRepository.save(sentence);
+    }
+
+    @Recover
+    public void recover(Exception e, Sentence sentence, String englishText, Long articleId) {
+        sentence.setTranslationStatus(Status.FAILED);
+        sentenceRepository.save(sentence);
+        log.error("번역 최종 실패({}회 시도) - sentenceId: {}, articleId: {}",
+                MAX_ATTEMPTS, sentence.getId(), articleId, e);
+    }
+}


### PR DESCRIPTION
## 🔍 변경 사항

번역 실패 시 재시도가 대기 없이 즉시 3회 반복되던 구조를 Spring Retry 기반으로 전환했습니다. 지수 백오프와 지터를 적용하고, 최종 실패 처리를 `@Recover`로 분리했습니다.

## 🔗 연결 이슈:
Closes #46

## 🛠️ 핵심 수정 사항 (How)

**의존성 · 설정**
- `spring-retry`, `spring-boot-starter-aop` 추가 (`@EnableRetry`가 AspectJ 오토프록시를 사용하므로 aspectjweaver 필요)
- `RetryConfig`에 `@EnableRetry`

**재시도 로직**
- `TranslationRetryService`(신규)에 `@Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500, multiplier = 2, maxDelay = 2000, random = true))`
- `random = true`로 `ExponentialRandomBackOffPolicy`가 선택되어 대기가 1차 `[500ms, 1000ms)`, 2차 `[1000ms, 2000ms)` 균등분포로 계산됩니다
- 3회 시도가 모두 실패하면 `@Recover`가 상태를 FAILED로 전이하고 로그를 남깁니다. 이후 기존 스케줄러(5분 간격, 최대 10회)가 재처리합니다

**빈 분리**
- `TranslationAsyncService`는 `@Async` 진입점만 담당하고 실제 호출·재시도는 `TranslationRetryService`에 위임합니다
- 같은 클래스 내 자기호출은 프록시를 거치지 않아 `@Retryable`이 적용되지 않으므로 반드시 별도 빈이어야 합니다. `@Async`와 `@Retryable`을 같은 메서드에 겹칠 때의 인터셉터 순서 문제도 함께 회피합니다
- `@Async` void 메서드의 예외는 호출자에게 전파되지 않으므로, 상태 전이를 예외 전파에 의존하지 않고 `@Recover` 안에서 직접 수행합니다

**정리**
- `translateAsync`의 미사용 파라미터 `orderIndex` 제거 (호출부 `SentenceService` 1줄 동반 수정)

## 남은 과제

- 재시도 불가 예외(`noRetryFor`) 분류 미적용
- 재시도·복구 경로를 검증하는 테스트 부재